### PR TITLE
Add error handling for security resolution

### DIFF
--- a/core/core/src/sf_core.rs
+++ b/core/core/src/sf_core.rs
@@ -222,7 +222,7 @@ impl SuperfaceCore {
         provider_parameters.append(&mut map_parameters);
         map_parameters = provider_parameters;
 
-        let map_security = prepare_security_map(&provider_json, &perform_input.map_security); // TODO SecurityMap
+        let map_security = prepare_security_map(&provider_json, &perform_input.map_security)?;
         let map_services = prepare_services_map(&provider_json, &map_parameters);
 
         // let mut profile_validator = ProfileValidator::new(

--- a/core/core_to_map_std/src/lib.rs
+++ b/core/core_to_map_std/src/lib.rs
@@ -104,6 +104,8 @@ macro_rules! define_exchange_map_to_core {
     };
 }
 
+use std::fmt::Write;
+
 pub mod unstable;
 
 pub trait CoreToMapStd: unstable::MapStdUnstable {}
@@ -117,7 +119,32 @@ pub enum MapInterpreterRunError {
     Error(String),
     #[error("Map code cannot be an empty string")]
     MapCodeEmpty,
+    #[error("Security is misconfigured:\n{}", MapInterpreterSecurityMisconfiguredError::format_errors(.0.as_slice()))]
+    SecurityMisconfigured(Vec<MapInterpreterSecurityMisconfiguredError>),
 }
+
+#[derive(Debug)]
+pub struct MapInterpreterSecurityMisconfiguredError {
+    pub id: String,
+    pub expected: String,
+}
+impl MapInterpreterSecurityMisconfiguredError {
+    fn format_errors(errors: &[MapInterpreterSecurityMisconfiguredError]) -> String {
+        let mut res = String::new();
+
+        for err in errors {
+            writeln!(
+                &mut res,
+                "Value for {} is misconfigured. Expected {}",
+                err.id, err.expected
+            )
+            .unwrap();
+        }
+
+        res
+    }
+}
+
 pub trait MapInterpreter {
     fn run(
         &mut self,


### PR DESCRIPTION
This error shows when security values is misconfigured:
<img width="823" alt="Screenshot 2023-05-02 at 19 39 07" src="https://user-images.githubusercontent.com/959390/235744178-c41199e7-2f43-4802-bb6b-4906bed72994.png">

This when map uses actual security, which doesn't have security configured. It is this way as we will know only at the time of the request if the security is really needed.
<img width="1247" alt="Screenshot 2023-05-02 at 19 41 54" src="https://user-images.githubusercontent.com/959390/235744182-fa6fccdd-0ff4-4bc2-a0d5-1d2a6dcad1c7.png">
