### PR TITLE
make host_to_core std more testable

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -191,7 +191,6 @@ dependencies = [
 name = "host_to_core_std"
 version = "0.1.0"
 dependencies = [
- "host_to_core_std",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -25,6 +25,3 @@ base64 = { workspace = true }
 
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-# [dev-dependencies]
-# sf_std = { path = "../host_to_core_std", package = "host_to_core_std", features = ["stub_ffi"] }

--- a/core/core/src/bindings.rs
+++ b/core/core/src/bindings.rs
@@ -129,9 +129,6 @@ extern "C" fn __import_stream_write(
     unreachable!()
 }
 #[cfg(test)]
-extern "C" fn __import_stream_close(handle: Handle) -> AbiResultRepr {
-    // this is actually called in tests which construct IoStreams, so we always succeed here
-    // TODO: this should possibly be configurable on per-test basis
-    assert_ne!(handle, 0);
-    0
+extern "C" fn __import_stream_close(_handle: Handle) -> AbiResultRepr {
+    unreachable!()
 }

--- a/core/core/src/bindings.rs
+++ b/core/core/src/bindings.rs
@@ -1,0 +1,137 @@
+use sf_std::abi::{
+    AbiResultRepr, Handle, MessageExchange, MessageExchangeFfiFn, Ptr, Size, StaticMessageExchange,
+    StaticStreamExchange, StreamExchange, StreamExchangeFfiFn,
+};
+
+//////////////
+// MESSAGES //
+//////////////
+
+pub struct MessageExchangeFfi;
+impl MessageExchangeFfi {
+    // SAFETY: We choose to trust this FFI.
+    const FFI: MessageExchangeFfiFn = unsafe {
+        MessageExchangeFfiFn::new(
+            __import_message_exchange,
+            __import_message_exchange_retrieve,
+        )
+    };
+}
+impl MessageExchange for MessageExchangeFfi {
+    fn invoke(&self, message: &[u8]) -> Vec<u8> {
+        Self::FFI.invoke(message)
+    }
+}
+impl StaticMessageExchange for MessageExchangeFfi {
+    fn instance() -> Self {
+        Self
+    }
+}
+
+#[cfg(not(test))]
+#[link(wasm_import_module = "sf_host_unstable")]
+extern "C" {
+    #[link_name = "message_exchange"]
+    fn __import_message_exchange(
+        msg_ptr: Ptr<u8>,
+        msg_len: Size,
+        out_ptr: Ptr<u8>,
+        out_len: Size,
+        ret_handle: Ptr<Handle>,
+    ) -> Size;
+
+    #[link_name = "message_exchange_retrieve"]
+    fn __import_message_exchange_retrieve(
+        handle: Handle,
+        out_ptr: Ptr<u8>,
+        out_len: Size,
+    ) -> AbiResultRepr;
+}
+#[cfg(test)]
+extern "C" fn __import_message_exchange(
+    _msg_ptr: Ptr<u8>,
+    _msg_len: Size,
+    _out_ptr: Ptr<u8>,
+    _out_len: Size,
+    _ret_handle: Ptr<Handle>,
+) -> Size {
+    unreachable!()
+}
+#[cfg(test)]
+extern "C" fn __import_message_exchange_retrieve(
+    _handle: Handle,
+    _out_ptr: Ptr<u8>,
+    _out_len: Size,
+) -> AbiResultRepr {
+    unreachable!()
+}
+
+/////////////
+// STREAMS //
+/////////////
+
+pub struct StreamExchangeFfi;
+impl StreamExchangeFfi {
+    // SAFETY: We choose to trust this FFI.
+    const FFI: StreamExchangeFfiFn = unsafe {
+        StreamExchangeFfiFn::new(
+            __import_stream_read,
+            __import_stream_write,
+            __import_stream_close,
+        )
+    };
+}
+impl StreamExchange for StreamExchangeFfi {
+    fn read(&self, handle: Handle, buf: &mut [u8]) -> std::io::Result<Size> {
+        Self::FFI.read(handle, buf)
+    }
+
+    fn write(&self, handle: Handle, buf: &[u8]) -> std::io::Result<Size> {
+        Self::FFI.write(handle, buf)
+    }
+
+    fn close(&self, handle: Handle) -> std::io::Result<()> {
+        Self::FFI.close(handle)
+    }
+}
+impl StaticStreamExchange for StreamExchangeFfi {
+    fn instance() -> Self {
+        Self
+    }
+}
+
+#[cfg(not(test))]
+#[link(wasm_import_module = "sf_host_unstable")]
+extern "C" {
+    #[link_name = "stream_read"]
+    fn __import_stream_read(handle: Handle, out_ptr: Ptr<u8>, out_len: Size) -> AbiResultRepr;
+
+    #[link_name = "stream_write"]
+    fn __import_stream_write(handle: Handle, in_ptr: Ptr<u8>, in_len: Size) -> AbiResultRepr;
+
+    #[link_name = "stream_close"]
+    fn __import_stream_close(handle: Handle) -> AbiResultRepr;
+}
+#[cfg(test)]
+extern "C" fn __import_stream_read(
+    _handle: Handle,
+    _out_ptr: Ptr<u8>,
+    _out_len: Size,
+) -> AbiResultRepr {
+    unreachable!()
+}
+#[cfg(test)]
+extern "C" fn __import_stream_write(
+    _handle: Handle,
+    _in_ptr: Ptr<u8>,
+    _in_len: Size,
+) -> AbiResultRepr {
+    unreachable!()
+}
+#[cfg(test)]
+extern "C" fn __import_stream_close(handle: Handle) -> AbiResultRepr {
+    // this is actually called in tests which construct IoStreams, so we always succeed here
+    // TODO: this should possibly be configurable on per-test basis
+    assert_ne!(handle, 0);
+    0
+}

--- a/core/core/src/lib.rs
+++ b/core/core/src/lib.rs
@@ -1,16 +1,19 @@
 use std::sync::Mutex;
 
+use bindings::MessageExchangeFfi;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use sf_std::{
     abi::{Ptr, Size},
     unstable::perform::{
-        set_perform_output_error, set_perform_output_exception, set_perform_output_result,
+        set_perform_output_error_in, set_perform_output_exception_in, set_perform_output_result_in,
     },
 };
 
 mod sf_core;
 use sf_core::{CoreConfiguration, SuperfaceCore};
+
+mod bindings;
 
 static GLOBAL_STATE: Mutex<Option<SuperfaceCore>> = Mutex::new(None);
 
@@ -91,9 +94,9 @@ pub extern "C" fn __export_superface_core_perform() {
         .expect("Global state missing: has superface_core_setup been called?");
 
     match state.perform() {
-        Ok(Ok(result)) => set_perform_output_result(result),
-        Ok(Err(error)) => set_perform_output_error(error),
-        Err(exception) => set_perform_output_exception(exception.into()),
+        Ok(Ok(result)) => set_perform_output_result_in(result, MessageExchangeFfi),
+        Ok(Err(error)) => set_perform_output_error_in(error, MessageExchangeFfi),
+        Err(exception) => set_perform_output_exception_in(exception.into(), MessageExchangeFfi),
     }
 }
 

--- a/core/core/src/sf_core/cache.rs
+++ b/core/core/src/sf_core/cache.rs
@@ -4,10 +4,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use sf_std::unstable::{
-    fs::OpenOptions,
-    http::{HttpCallError, HttpRequest},
-};
+use sf_std::unstable::http::HttpCallError;
+
+use super::{Fs, HttpRequest};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DocumentCacheError {
@@ -112,18 +111,8 @@ impl DocumentCache {
                 url.to_string(),
                 std::io::ErrorKind::NotFound.into(),
             )),
-            Some(path) => {
-                let mut file = OpenOptions::new()
-                    .read(true)
-                    .open(&path)
-                    .map_err(|err| DocumentCacheError::FileLoadFailed(path.to_string(), err))?;
-
-                let mut data = Vec::new();
-                file.read_to_end(&mut data)
-                    .map_err(|err| DocumentCacheError::FileLoadFailed(path.to_string(), err))?;
-
-                Ok(data)
-            }
+            Some(path) => Fs::read(path)
+                .map_err(|err| DocumentCacheError::FileLoadFailed(path.to_string(), err)),
         }
     }
 

--- a/core/core/src/sf_core/map_std_impl.rs
+++ b/core/core/src/sf_core/map_std_impl.rs
@@ -10,10 +10,9 @@ use map_std::{
     },
     MapStdFull,
 };
-use sf_std::{
-    abi::Handle,
-    unstable::{http::HttpRequest, IoStream},
-};
+use sf_std::abi::Handle;
+
+use super::{HttpRequest, IoStream};
 
 pub struct MapStdImpl {
     http_requests: HandleMap<HttpRequest>,

--- a/core/core/src/sf_core/profile_validator.rs
+++ b/core/core/src/sf_core/profile_validator.rs
@@ -2,12 +2,10 @@
 
 use thiserror::Error;
 
-use sf_std::unstable::fs;
-
 use interpreter_js::{JsInterpreter, JsInterpreterError};
 use map_std::unstable::MapValue;
 
-use super::map_std_impl::MapStdImpl;
+use super::{map_std_impl::MapStdImpl, Fs};
 
 #[derive(Debug, Error)]
 pub enum ProfileValidatorError {
@@ -39,7 +37,7 @@ impl ProfileValidator {
         let validator_bytecode = match std::env::var("SF_REPLACE_PROFILE_VALIDATOR").ok() {
             None => interpreter.compile_code("profile_validator.js", Self::PROFILE_VALIDATOR_JS),
             Some(path) => {
-                let replacement = fs::read_to_string(&path)
+                let replacement = Fs::read_to_string(&path)
                     .expect("Failed to load replacement profile_validator");
                 interpreter.compile_code(&path, &replacement)
             }

--- a/core/core_to_map_std/Cargo.toml
+++ b/core/core_to_map_std/Cargo.toml
@@ -15,6 +15,3 @@ base64 = { workspace = true }
 slab = "0.4"
 
 sf_std = { path = "../host_to_core_std", package = "host_to_core_std" }
-
-[dev-dependencies]
-sf_std = { path = "../host_to_core_std", package = "host_to_core_std", features = ["stub_ffi"] }

--- a/core/host_to_core_std/Cargo.toml
+++ b/core/host_to_core_std/Cargo.toml
@@ -6,10 +6,6 @@ publish = false
 
 [features]
 default = []
-# stub out ffi/imports, so that this module can be run without host environemnt
-# this is intended to enable testing this and dependent modules which won't have host
-# imports available during testing
-stub_ffi = []
 
 [dependencies]
 thiserror = { workspace = true }
@@ -20,6 +16,3 @@ serde_urlencoded = { workspace = true }
 url = { workspace = true }
 
 tracing = { workspace = true }
-
-[dev-dependencies]
-host_to_core_std = { path = ".", features = ["stub_ffi"] }

--- a/core/host_to_core_std/src/abi/mod.rs
+++ b/core/host_to_core_std/src/abi/mod.rs
@@ -26,6 +26,12 @@ mod result;
 
 pub use self::{
     bits::{AbiPair, AbiPairRepr, Handle, Ptr, Size},
-    exchange::{JsonMessageError, MessageFn, StreamFn},
+    exchange::{
+        JsonMessageError, MessageExchange, MessageExchangeFfiFn, StaticMessageExchange,
+        StaticStreamExchange, StreamExchange, StreamExchangeFfiFn,
+    },
     result::{err_from_wasi_errno, AbiResult, AbiResultRepr},
 };
+
+#[cfg(test)]
+pub use exchange::testing;

--- a/core/host_to_core_std/src/lib.rs
+++ b/core/host_to_core_std/src/lib.rs
@@ -75,9 +75,10 @@ macro_rules! define_exchange_core_to_host {
                     $( $field_name ),*
                 }
             }
-        }
-        impl $(<$life>)? $crate::MessageExchange for $name $(<$life>)? {
-            type Response = $response_name;
+
+            pub fn send_json_in<E: $crate::abi::MessageExchange>(&self, message_exchange: E) -> Result<$response_name, $crate::abi::JsonMessageError> {
+                message_exchange.invoke_json(self)
+            }
         }
 
         $( #[$out_attr] )*
@@ -97,21 +98,8 @@ macro_rules! define_exchange_core_to_host {
 
 use std::collections::HashMap;
 
-use serde::{de::DeserializeOwned, Serialize};
-
 pub mod abi;
-use abi::{JsonMessageError, MessageFn};
-
 pub mod unstable;
-
-trait MessageExchange: Sized + Serialize {
-    type Response: DeserializeOwned;
-
-    /// Convenience for invoking `fun` and expecting `Self::Response`.
-    fn send_json(&self, fun: &MessageFn) -> Result<Self::Response, JsonMessageError> {
-        fun.invoke_json(self)
-    }
-}
 
 pub type MultiMap = HashMap<String, Vec<String>>;
 // TODO: consider making the key always lowercase at the type level somehow

--- a/core/host_to_core_std/src/unstable/fs.rs
+++ b/core/host_to_core_std/src/unstable/fs.rs
@@ -14,7 +14,7 @@ use crate::abi::{
 // even though wasmtime rust crate has this API, wasmer is more complex).
 //
 // Instead we rely on our own read/write/close methods and only expose `Read` and `Write` for now. the `fs::File` API will still work
-// but only for files which have been preopened through WASI, otherwise we'll rely on out messages and streams.
+// but only for files which have been preopened through WASI, otherwise we'll rely on our messages and streams.
 
 define_exchange_core_to_host! {
     struct FileOpenRequest<'a> {
@@ -89,7 +89,6 @@ impl OpenOptions {
         self
     }
 
-    // TODO: Should we also change the StreamExchange of the returned IoStream?
     pub fn open_in<Me: MessageExchange, Se: StreamExchange>(
         &self,
         path: &str,
@@ -122,6 +121,7 @@ pub struct FsConvenience<Me: StaticMessageExchange, Se: StaticStreamExchange>(
     std::marker::PhantomData<(Me, Se)>,
 );
 impl<Me: StaticMessageExchange, Se: StaticStreamExchange> FsConvenience<Me, Se> {
+    /// Like [std::fs::read].
     pub fn read(path: &str) -> Result<Vec<u8>, io::Error> {
         let mut file =
             OpenOptions::new()
@@ -133,6 +133,8 @@ impl<Me: StaticMessageExchange, Se: StaticStreamExchange> FsConvenience<Me, Se> 
 
         Ok(data)
     }
+
+    /// Like [std::fs::read_to_string].
     pub fn read_to_string(path: &str) -> Result<String, io::Error> {
         let mut file =
             OpenOptions::new()

--- a/core/host_to_core_std/src/unstable/fs.rs
+++ b/core/host_to_core_std/src/unstable/fs.rs
@@ -2,8 +2,11 @@ use std::io::{self, Read};
 
 use serde::{Deserialize, Serialize};
 
-use super::{IoStream, MessageExchange, EXCHANGE_MESSAGE};
-use crate::abi::{err_from_wasi_errno, Size};
+use super::{IoStream, IoStreamHandle};
+use crate::abi::{
+    err_from_wasi_errno, MessageExchange, Size, StaticMessageExchange, StaticStreamExchange,
+    StreamExchange,
+};
 
 // Initial idea was to use the file-open message to obtain a fd from the host
 // the use it with `std::fs::File::from_raw_fd`, but the ability to allocate/inject fds into
@@ -26,7 +29,7 @@ define_exchange_core_to_host! {
         create_new: bool,
     } -> enum FileOpenResponse {
         Ok {
-            stream: IoStream
+            stream: IoStreamHandle
         },
         Err { errno: Size }
     }
@@ -86,7 +89,13 @@ impl OpenOptions {
         self
     }
 
-    pub fn open(&self, path: &str) -> Result<IoStream, io::Error> {
+    // TODO: Should we also change the StreamExchange of the returned IoStream?
+    pub fn open_in<Me: MessageExchange, Se: StreamExchange>(
+        &self,
+        path: &str,
+        message_exchange: Me,
+        stream_exchange: Se,
+    ) -> Result<IoStream<Se>, io::Error> {
         let response = FileOpenRequest {
             kind: FileOpenRequest::KIND,
             path,
@@ -97,21 +106,42 @@ impl OpenOptions {
             create: self.create,
             create_new: self.create_new,
         }
-        .send_json(&EXCHANGE_MESSAGE)
+        .send_json_in(message_exchange)
         .unwrap();
 
         match response {
-            FileOpenResponse::Ok { stream } => Ok(stream),
+            FileOpenResponse::Ok { stream } => {
+                Ok(IoStream::from_handle_in(stream, stream_exchange))
+            }
             FileOpenResponse::Err { errno } => Err(err_from_wasi_errno(errno)),
         }
     }
 }
 
-pub fn read_to_string(path: &str) -> Result<String, io::Error> {
-    let mut file = OpenOptions::new().read(true).open(path.as_ref())?;
+pub struct FsConvenience<Me: StaticMessageExchange, Se: StaticStreamExchange>(
+    std::marker::PhantomData<(Me, Se)>,
+);
+impl<Me: StaticMessageExchange, Se: StaticStreamExchange> FsConvenience<Me, Se> {
+    pub fn read(path: &str) -> Result<Vec<u8>, io::Error> {
+        let mut file =
+            OpenOptions::new()
+                .read(true)
+                .open_in(path.as_ref(), Me::instance(), Se::instance())?;
 
-    let mut data = String::new();
-    file.read_to_string(&mut data)?;
+        let mut data = Vec::new();
+        file.read_to_end(&mut data)?;
 
-    Ok(data)
+        Ok(data)
+    }
+    pub fn read_to_string(path: &str) -> Result<String, io::Error> {
+        let mut file =
+            OpenOptions::new()
+                .read(true)
+                .open_in(path.as_ref(), Me::instance(), Se::instance())?;
+
+        let mut data = String::new();
+        file.read_to_string(&mut data)?;
+
+        Ok(data)
+    }
 }

--- a/core/host_to_core_std/src/unstable/http.rs
+++ b/core/host_to_core_std/src/unstable/http.rs
@@ -223,7 +223,7 @@ mod test {
             TestMessageExchangeFn::new(|message| {
                 let query = message["url"].as_str().unwrap().split_once("?").unwrap().1;
                 let mut pairs = query.split("&").collect::<Vec<_>>();
-                pairs.sort();
+                pairs.sort(); // since query parameters don't have a set ordering and internally there is a hashmap, we have to make it deterministic by sorting the pairs
 
                 assert_eq!(
                     pairs,

--- a/core/host_to_core_std/src/unstable/stream.rs
+++ b/core/host_to_core_std/src/unstable/stream.rs
@@ -1,49 +1,89 @@
 use serde::{Deserialize, Serialize};
 
-use super::STREAM_IO;
-use crate::abi::Handle;
+use crate::abi::{Handle, StaticStreamExchange, StreamExchange, StreamExchangeFfiFn};
 
-/// Stream which can be read from or written to.
+/// Represents an IoStream handle without an exchange.
 ///
-/// Not all streams can be both read from and written to, those will return an error.
+/// This is used to represent a state where a handle has been deserialized but the deserialized cannot know what exchange should be associated with it.
 #[derive(Debug, PartialEq, Eq)]
-pub struct IoStream(Handle);
-impl IoStream {
+pub struct IoStreamHandle(Handle);
+impl IoStreamHandle {
     pub(crate) fn from_raw_handle(handle: Handle) -> Self {
         Self(handle)
     }
-
-    // pub(crate) fn to_raw_handle(&self) -> usize {
-    //     self.0
-    // }
 }
-impl std::io::Read for IoStream {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        STREAM_IO.read(self.0, buf)
-    }
-}
-impl std::io::Write for IoStream {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        STREAM_IO.write(self.0, buf)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        // this is a no-op right now
-        Ok(())
-    }
-}
-impl Drop for IoStream {
-    fn drop(&mut self) {
-        STREAM_IO.close(self.0).unwrap()
-    }
-}
-impl Serialize for IoStream {
+impl Serialize for IoStreamHandle {
     fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
         self.0.serialize(ser)
     }
 }
-impl<'de> Deserialize<'de> for IoStream {
-    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<IoStream, D::Error> {
-        Handle::deserialize(de).map(IoStream::from_raw_handle)
+impl<'de> Deserialize<'de> for IoStreamHandle {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        Handle::deserialize(de).map(Self)
     }
 }
+
+/// Stream which can be read from or written to.
+///
+/// Not all streams can be both read from and written to, those will return an error.
+pub struct IoStream<E: StreamExchange = StreamExchangeFfiFn>(Handle, E);
+// impl Serialize for IoStream<StreamExchangeFfi> {
+//     fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+//         self.0.serialize(ser)
+//     }
+// }
+// impl<'de> Deserialize<'de> for IoStream<StreamExchangeFfi> {
+//     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+//         Handle::deserialize(de)
+//             .map(|handle| IoStream::from_raw_handle_in(handle, STREAM_EXCHANGE_FFI))
+//     }
+// }
+impl<E: StaticStreamExchange> IoStream<E> {
+    pub fn from_handle(handle: IoStreamHandle) -> Self {
+        Self::from_handle_in(handle, E::instance())
+    }
+}
+impl<E: StreamExchange> IoStream<E> {
+    pub fn from_handle_in(handle: IoStreamHandle, exchange: E) -> Self {
+        Self(handle.0, exchange)
+    }
+
+    pub fn into_handle(self) -> IoStreamHandle {
+        IoStreamHandle(self.0)
+    }
+
+    // pub(crate) fn set_exchange<O: StreamExchange>(self, exchange: E) -> IoStream<O> {
+    //     Self(self.0, exchange)
+    // }
+}
+impl<E: StreamExchange> std::io::Read for IoStream<E> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.1.read(self.0, buf)
+    }
+}
+impl<E: StreamExchange> std::io::Write for IoStream<E> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.1.write(self.0, buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // TODO: this is a no-op right now
+        Ok(())
+    }
+}
+impl<E: StreamExchange> Drop for IoStream<E> {
+    fn drop(&mut self) {
+        self.1.close(self.0).unwrap()
+    }
+}
+impl<E: StreamExchange> std::fmt::Debug for IoStream<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("IoStream").field(&self.0).finish()
+    }
+}
+impl<E: StreamExchange> PartialEq for IoStream<E> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+impl<E: StreamExchange> Eq for IoStream<E> {}

--- a/core/host_to_core_std/src/unstable/stream.rs
+++ b/core/host_to_core_std/src/unstable/stream.rs
@@ -8,6 +8,7 @@ use crate::abi::{Handle, StaticStreamExchange, StreamExchange, StreamExchangeFfi
 #[derive(Debug, PartialEq, Eq)]
 pub struct IoStreamHandle(Handle);
 impl IoStreamHandle {
+    #[cfg(test)]
     pub(crate) fn from_raw_handle(handle: Handle) -> Self {
         Self(handle)
     }
@@ -27,17 +28,6 @@ impl<'de> Deserialize<'de> for IoStreamHandle {
 ///
 /// Not all streams can be both read from and written to, those will return an error.
 pub struct IoStream<E: StreamExchange = StreamExchangeFfiFn>(Handle, E);
-// impl Serialize for IoStream<StreamExchangeFfi> {
-//     fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-//         self.0.serialize(ser)
-//     }
-// }
-// impl<'de> Deserialize<'de> for IoStream<StreamExchangeFfi> {
-//     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-//         Handle::deserialize(de)
-//             .map(|handle| IoStream::from_raw_handle_in(handle, STREAM_EXCHANGE_FFI))
-//     }
-// }
 impl<E: StaticStreamExchange> IoStream<E> {
     pub fn from_handle(handle: IoStreamHandle) -> Self {
         Self::from_handle_in(handle, E::instance())
@@ -51,10 +41,6 @@ impl<E: StreamExchange> IoStream<E> {
     pub fn into_handle(self) -> IoStreamHandle {
         IoStreamHandle(self.0)
     }
-
-    // pub(crate) fn set_exchange<O: StreamExchange>(self, exchange: E) -> IoStream<O> {
-    //     Self(self.0, exchange)
-    // }
 }
 impl<E: StreamExchange> std::io::Read for IoStream<E> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {

--- a/core/host_to_core_std/src/unstable/value.rs
+++ b/core/host_to_core_std/src/unstable/value.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
 
-use super::IoStream;
+use super::IoStreamHandle;
 
 /// Similar to [serde_json::Value], it is able to represent any value passed in as input or output.
 ///
@@ -12,7 +12,7 @@ use super::IoStream;
 #[derive(Debug, PartialEq, Eq)]
 pub enum HostValue {
     // custom
-    Stream(IoStream),
+    Stream(IoStreamHandle),
     // standard
     None,
     Bool(bool),
@@ -126,7 +126,7 @@ impl<'de> Deserialize<'de> for HostValue {
                 let values = match visitor.next_key::<String>()? {
                     None => BTreeMap::new(),
                     Some(key) if key == HostValue::CUSTOM_TYPE_STREAM => {
-                        let stream: IoStream = visitor.next_value()?;
+                        let stream: IoStreamHandle = visitor.next_value()?;
 
                         return Ok(HostValue::Stream(stream));
                     }

--- a/core/interpreter_js/Cargo.toml
+++ b/core/interpreter_js/Cargo.toml
@@ -20,6 +20,3 @@ serde_urlencoded = { workspace = true }
 base64 = { workspace = true }
 
 tracing = { workspace = true }
-
-[dev-dependencies]
-sf_std = { path = "../host_to_core_std", package = "host_to_core_std", features = ["stub_ffi"] }


### PR DESCRIPTION
* inspired by rust allocator API, calls against message exchange FFI and stream exchange FFI can be replaced by custom implementation/closure, mainly in tests
* run cargo fmt

See this test for an example on how this improves testability: https://github.com/superfaceai/one-sdk/pull/19/files#diff-bb06d5ff668217765af2c523f4b6e6972eef329c45f3436d112c4a670d0f1370R213