### PR TITLE
Split cache for cargo

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -22,7 +22,9 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/registry/index
             core/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-debug
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
       - name: Cache WASI SDK
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/registry/index
             core/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-release
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
       - name: Cache WASI SDK
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
For CI/CD pipeline, core/target is restored from cache. It contains only release build of dependencies, so they are rebuilt for every CI/CD run.

By splitting cache, it should be avoided.