### PR TITLE
Add sdkAuthToken as client option

### DIFF
--- a/host/js/src/cloudflare/index.ts
+++ b/host/js/src/cloudflare/index.ts
@@ -39,7 +39,7 @@ class CfwFileSystem implements FileSystem {
     if (data === undefined) {
       throw new WasiError(WasiErrno.EBADF);
     }
-    
+
     return this.files.insert({ data, cursor: 0 });
   }
   async read(handle: number, out: Uint8Array): Promise<number> {
@@ -62,7 +62,7 @@ class CfwFileSystem implements FileSystem {
     if (file === undefined) {
       throw new WasiError(WasiErrno.EBADF);
     }
-    
+
     throw new WasiError(WasiErrno.EROFS);
   }
   async close(handle: number): Promise<void> {
@@ -134,14 +134,14 @@ class CfwWasiCompat implements WasiContext {
     iovs_len: number
   ): Array<Uint8Array> {
     let result = Array<Uint8Array>(iovs_len)
-  
+
     for (let i = 0; i < iovs_len; i++) {
       const bufferPtr = view.getUint32(iovs_ptr, true)
       iovs_ptr += 4
-  
+
       const bufferLen = view.getUint32(iovs_ptr, true)
       iovs_ptr += 4
-  
+
       result[i] = new Uint8Array(view.buffer, bufferPtr, bufferLen)
     }
     return result
@@ -180,6 +180,7 @@ class CfwWasiCompat implements WasiContext {
 export type ClientOptions = {
   env?: Record<string, string>;
   assetsPath?: string;
+  sdkAuthToken?: string;
   preopens?: Record<string, Uint8Array>;
 };
 

--- a/host/js/src/node/index.ts
+++ b/host/js/src/node/index.ts
@@ -118,7 +118,16 @@ class NodeNetwork implements Network {
 }
 
 export type ClientOptions = {
+  /**
+   * Path to folder with Comlink's assets.
+   */
   assetsPath?: string;
+  /**
+   * Optionally authenticate Client to send metrics about integration to Superface.
+   * 
+   * Manage tokens and see insights here: https://superface.ai/insights
+   */
+  sdkAuthToken?: string;
 };
 
 export type ClientPerformOptions = {
@@ -128,7 +137,8 @@ export type ClientPerformOptions = {
 };
 
 class InternalClient {
-  public assetsPath: string = process.cwd();
+  public assetsPath: string = process.cwd(); // TODO: point to `superface` folder
+  private token: string | undefined;
 
   private corePath: string;
   private wasi: WASI;
@@ -138,6 +148,10 @@ class InternalClient {
   constructor(readonly options: ClientOptions = {}) {
     if (options.assetsPath !== undefined) {
       this.assetsPath = options.assetsPath;
+    }
+
+    if (options.sdkAuthToken !== undefined) {
+      this.token = options.sdkAuthToken;
     }
 
     this.corePath = CORE_PATH;


### PR DESCRIPTION
- adds `sdkAuthToken` to node.js and Cloudflare client.

I am keeping `sdkAuthToken` to keep it same as for original OneSDK. Same for CF Worker, not to name same thing with different names.