### PR TITLE
Feat/tracing layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ This will require to have Development requirements installed. In case of buildin
 ### Environment variables
 
 The OneSDK uses these environment variables:
-* `OSDK_LOG=warn` - controls the level of logging intended for users, see [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax
-* `OSDK_REGISTRY_URL=http://localhost:8321` - Superface registry base URL
-* `OSDK_CONFIG_CACHE_DURATION=3600` - duration in seconds of how long to cache documents (profiles, maps, providers) before downloading or reading them from the file system again
-* `OSDK_CONFIG_DEV_DUMP_BUFFER_SIZE=1048576` - size of the developer log dump ring buffer
-* `OSDK_DEV_LOG=off` - controls the level of logging intended for developers, see [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax
-* `OSDK_REPLACE_MAP_STDLIB=` - path to replacement map stdlib, intended for development only, may be removed at any time
+* `ONESDK_LOG=warn` - controls the level of logging intended for users, see [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax
+* `ONESDK_REGISTRY_URL=http://localhost:8321` - Superface registry base URL
+* `ONESDK_CONFIG_CACHE_DURATION=3600` - duration in seconds of how long to cache documents (profiles, maps, providers) before downloading or reading them from the file system again
+* `ONESDK_CONFIG_DEV_DUMP_BUFFER_SIZE=1048576` - size of the developer log dump ring buffer
+* `ONESDK_DEV_LOG=off` - controls the level of logging intended for developers, see [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax
+* `ONESDK_REPLACE_MAP_STDLIB=` - path to replacement map stdlib, intended for development only, may be removed at any time
 
 ## Supported languages
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,19 @@ For more details about Superface, visit [How it Works](https://superface.ai/how-
 
 ## Try it out
 
-A simple demonstration can be run with `./examples/run.sh node [CORE_MODE=default|docker|lax]`. It builds entire projects and Node.js host, then runs the example.
+A simple demonstration can be run with `./examples/run.sh node [CORE_MODE=default|docker|lax]`. It builds the entire project and Node.js host, then runs the example.
 
 This will require to have Development requirements installed. In case of building the core in Docker `node` and `yarn` are still required.
+
+### Environment variables
+
+The OneSDK uses these environment variables:
+* `OSDK_LOG=warn` - controls the level of logging intended for users, see [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax
+* `OSDK_REGISTRY_URL=http://localhost:8321` - Superface registry base URL
+* `OSDK_CONFIG_CACHE_DURATION=3600` - duration in seconds of how long to cache documents (profiles, maps, providers) before downloading or reading them from the file system again
+* `OSDK_CONFIG_DEV_DUMP_BUFFER_SIZE=1048576` - size of the developer log dump ring buffer
+* `OSDK_DEV_LOG=off` - controls the level of logging intended for developers, see [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax
+* `OSDK_REPLACE_MAP_STDLIB=` - path to replacement map stdlib, intended for development only, may be removed at any time
 
 ## Supported languages
 

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -671,6 +671,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,12 +690,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -25,4 +25,4 @@ interpreter_js = { path = "../interpreter_js" }
 base64 = { workspace = true }
 
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }

--- a/core/core/src/lib.rs
+++ b/core/core/src/lib.rs
@@ -51,7 +51,7 @@ pub extern "C" fn __export_oneclient_core_setup() {
 
     // initialize observability
     // SAFETY: setup is only allowed to be called once
-    unsafe { observability::init(config.developer_log_buffer_size) };
+    unsafe { observability::init(config.developer_dump_buffer_size) };
     
     // now that we have logging we can start printing stuff
     tracing::debug!(target: "@user", "oneclient_core_setup called");

--- a/core/core/src/mock.rs
+++ b/core/core/src/mock.rs
@@ -29,7 +29,7 @@ pub fn __export_oneclient_core_setup() {
                 .with_filter(
                     EnvFilter::builder()
                         .with_default_directive(LevelFilter::TRACE.into())
-                        .with_env_var("OSDK_DEV_LOG")
+                        .with_env_var("ONESDK_DEV_LOG")
                         .from_env_lossy(),
                 )
         )

--- a/core/core/src/mock.rs
+++ b/core/core/src/mock.rs
@@ -22,8 +22,16 @@ pub fn __export_oneclient_core_setup() {
 
     // initialize tracing
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
-        .with(tracing_subscriber::EnvFilter::from_env("SF_LOG"))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_filter(
+                    EnvFilter::builder()
+                        .with_default_directive(LevelFilter::TRACE.into())
+                        .with_env_var("OSDK_DEV_LOG")
+                        .from_env_lossy(),
+                )
+        )
         .init();
 
     tracing::debug!("mocked oneclient core setup");

--- a/core/core/src/mock.rs
+++ b/core/core/src/mock.rs
@@ -8,7 +8,8 @@ use sf_std::unstable::{
     perform::{set_perform_output_result_in, PerformInput},
     HostValue,
 };
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tracing::metadata::LevelFilter;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 use crate::bindings::MessageExchangeFfi;
 

--- a/core/core/src/observability/buffer.rs
+++ b/core/core/src/observability/buffer.rs
@@ -1,0 +1,211 @@
+use std::{
+    io::Write,
+    ops::DerefMut,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use tracing_subscriber::fmt::MakeWriter;
+
+/// Event buffer implementation.
+///
+/// For example it can be an unbounded buffer or a ring buffer.
+pub trait TracingEventBuffer: Sized {
+    /// Writes data into the buffer.
+    ///
+    /// Writing a null byte marks an event boundary.
+    fn write(&mut self, data: &[u8]);
+
+    /// Returns the bytes of the events starting at `start` including the trailing null byte.
+    fn next_event_line(&self, start: usize) -> Option<&'_ [u8]>;
+
+    /// Clears the internal buffer and removes all events.
+    fn clear(&mut self);
+
+    /// Returns an iterator over events in this buffer.
+    ///
+    /// This iterator does not consume the events. To clear the buffer afterwards call [TracingEventBuffer::clear].
+    fn events<'a>(&'a self) -> TracingEventBufferEventsIter<'a, Self> {
+        TracingEventBufferEventsIter {
+            buffer: self,
+            index: 0,
+        }
+    }
+}
+
+/// This is a tracing event buffer writer, which handles writing events and marking boundaries.
+///
+/// The event boundary is mentioned by this comment <https://github.com/tokio-rs/tracing/issues/1931#issuecomment-1042340765>
+/// and also mentioned in the docs <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html#implementer-notes>,
+/// so it should be valid approach to add the boundary on drop.
+pub struct TracingEventBufferWriter<'a, B: TracingEventBuffer, R: DerefMut<Target = B> + 'a> {
+    buffer: R,
+    _phantom: std::marker::PhantomData<&'a mut B>,
+}
+impl<'a, B: TracingEventBuffer, R: DerefMut<Target = B> + 'a> TracingEventBufferWriter<'a, B, R> {
+    pub fn new(buffer: R) -> Self {
+        Self {
+            buffer,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+impl<'a, B: TracingEventBuffer, R: DerefMut<Target = B> + 'a> Write
+    for TracingEventBufferWriter<'a, B, R>
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        debug_assert!(std::str::from_utf8(buf).is_ok());
+        // IDEA: possibly trim newlines from `buf` here
+        self.buffer.write(buf);
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+impl<'a, B: TracingEventBuffer, R: DerefMut<Target = B> + 'a> Drop
+    for TracingEventBufferWriter<'a, B, R>
+{
+    fn drop(&mut self) {
+        self.buffer.write(&[b'\0'])
+    }
+}
+
+pub struct TracingEventBufferEventsIter<'a, B: TracingEventBuffer> {
+    buffer: &'a B,
+    index: usize,
+}
+impl<'a, B: TracingEventBuffer> Iterator for TracingEventBufferEventsIter<'a, B> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.buffer.next_event_line(self.index) {
+            None => None,
+            Some(event) => {
+                self.index += event.len();
+
+                Some(std::str::from_utf8(&event[..event.len() - 1]).unwrap())
+            }
+        }
+    }
+}
+
+/// Wrapper around a [`TracingEventBuffer`](TracingEventBuffer) that can be shared between tracing and a consumer.
+#[derive(Debug)]
+pub struct SharedEventBuffer<B: TracingEventBuffer + 'static>(Arc<Mutex<B>>);
+impl<B: TracingEventBuffer> SharedEventBuffer<B> {
+    pub fn new(inner: B) -> Self {
+        Self(Arc::new(Mutex::new(inner)))
+    }
+
+    pub fn lock(&self) -> MutexGuard<'_, B> {
+        self.0.lock().unwrap()
+    }
+}
+impl<B: TracingEventBuffer> Clone for SharedEventBuffer<B> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+impl<'a, B: TracingEventBuffer + 'static> MakeWriter<'a> for SharedEventBuffer<B> {
+    type Writer = TracingEventBufferWriter<'a, B, MutexGuard<'a, B>>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        TracingEventBufferWriter::new(self.lock())
+    }
+}
+
+/// Inbounded buffer backed by `Vec<u8>`.
+pub struct VecEventBuffer {
+    /// Each event is terminated by a null byte. Otherwise there can be no null bytes in the strings because they are utf-8.
+    data: Vec<u8>,
+}
+impl VecEventBuffer {
+    pub fn new() -> Self {
+        Self { data: Vec::new() }
+    }
+}
+impl TracingEventBuffer for VecEventBuffer {
+    fn write(&mut self, data: &[u8]) {
+        self.data.extend(data.into_iter().copied())
+    }
+
+    fn next_event_line(&self, start: usize) -> Option<&'_ [u8]> {
+        if start >= self.data.len() {
+            return None;
+        }
+
+        let sub_data = &self.data[start..];
+        let end_offset = sub_data
+            .iter()
+            .position(|&b| b == b'\0')
+            .map(|p| p + 1)
+            .unwrap();
+
+        Some(&sub_data[..end_offset])
+    }
+
+    fn clear(&mut self) {
+        self.data.clear()
+    }
+}
+impl std::fmt::Debug for VecEventBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "VecBuffer(<{} events, {} bytes>)",
+            self.data.iter().filter(|&&b| b == b'\0').count(),
+            self.data.len()
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Write;
+
+    use super::{TracingEventBuffer, TracingEventBufferWriter, VecEventBuffer};
+
+    #[test]
+    fn test_event_buffer_writer() {
+        let mut buffer = VecEventBuffer::new();
+        let event =
+            "bananas are nice, this is a string\nwith a newline and 67 characters".to_string();
+
+        // this is the pattern of usage in tracing_subscriber
+        {
+            let mut writer = TracingEventBufferWriter::new(&mut buffer);
+            writer.write_all(event.as_bytes()).unwrap();
+        }
+        {
+            let mut writer = TracingEventBufferWriter::new(&mut buffer);
+            writer.write_all(event.as_bytes()).unwrap();
+        }
+        {
+            let mut writer = TracingEventBufferWriter::new(&mut buffer);
+            writer.write_all(event.as_bytes()).unwrap();
+        }
+
+        assert_eq!(buffer.data.len(), (event.len() + 1) * 3);
+        {
+            let events: Vec<&str> = buffer.events().collect();
+            assert_eq!(events, vec![event.as_str(), event.as_str(), event.as_str()]);
+        }
+
+        buffer.clear();
+        assert_eq!(buffer.data.len(), 0);
+    }
+
+    #[test]
+    fn test_vec_buffer_next_event_line() {
+        let mut buffer = VecEventBuffer::new();
+        assert_eq!(buffer.next_event_line(0), None);
+        assert_eq!(buffer.next_event_line(2), None);
+
+        buffer.write(b"abcd\0efgh\0");
+        assert_eq!(buffer.next_event_line(0).unwrap(), b"abcd\0");
+        assert_eq!(buffer.next_event_line(5).unwrap(), b"efgh\0");
+        assert_eq!(buffer.next_event_line(10), None);
+    }
+}

--- a/core/core/src/observability/buffer.rs
+++ b/core/core/src/observability/buffer.rs
@@ -1,35 +1,37 @@
 use std::{
     io::Write,
     ops::DerefMut,
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard}, borrow::Borrow
 };
 
 use tracing_subscriber::fmt::MakeWriter;
 
+mod ring;
+mod vec;
+
+pub use self::{
+    ring::RingEventBuffer,
+    vec::VecEventBuffer
+};
+
+const EVENT_SEPARATOR: u8 = b'\0';
+
 /// Event buffer implementation.
 ///
 /// For example it can be an unbounded buffer or a ring buffer.
-pub trait TracingEventBuffer: Sized {
+pub(crate) trait TracingEventBuffer: Sized {
+    type RawParts: Borrow<[(*const u8, usize)]>;
+
     /// Writes data into the buffer.
     ///
     /// Writing a null byte marks an event boundary.
     fn write(&mut self, data: &[u8]);
 
-    /// Returns the bytes of the events starting at `start` including the trailing null byte.
-    fn next_event_line(&self, start: usize) -> Option<&'_ [u8]>;
+    /// Returns raw pointer and size tuples which represent the memory of the buffer.
+    fn as_raw_parts(&self) -> Self::RawParts;
 
     /// Clears the internal buffer and removes all events.
     fn clear(&mut self);
-
-    /// Returns an iterator over events in this buffer.
-    ///
-    /// This iterator does not consume the events. To clear the buffer afterwards call [TracingEventBuffer::clear].
-    fn events<'a>(&'a self) -> TracingEventBufferEventsIter<'a, Self> {
-        TracingEventBufferEventsIter {
-            buffer: self,
-            index: 0,
-        }
-    }
 }
 
 /// This is a tracing event buffer writer, which handles writing events and marking boundaries.
@@ -37,7 +39,7 @@ pub trait TracingEventBuffer: Sized {
 /// The event boundary is mentioned by this comment <https://github.com/tokio-rs/tracing/issues/1931#issuecomment-1042340765>
 /// and also mentioned in the docs <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html#implementer-notes>,
 /// so it should be valid approach to add the boundary on drop.
-pub struct TracingEventBufferWriter<'a, B: TracingEventBuffer, R: DerefMut<Target = B> + 'a> {
+pub(crate) struct TracingEventBufferWriter<'a, B: TracingEventBuffer, R: DerefMut<Target = B> + 'a> {
     buffer: R,
     _phantom: std::marker::PhantomData<&'a mut B>,
 }
@@ -68,32 +70,13 @@ impl<'a, B: TracingEventBuffer, R: DerefMut<Target = B> + 'a> Drop
     for TracingEventBufferWriter<'a, B, R>
 {
     fn drop(&mut self) {
-        self.buffer.write(&[b'\0'])
-    }
-}
-
-pub struct TracingEventBufferEventsIter<'a, B: TracingEventBuffer> {
-    buffer: &'a B,
-    index: usize,
-}
-impl<'a, B: TracingEventBuffer> Iterator for TracingEventBufferEventsIter<'a, B> {
-    type Item = &'a str;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.buffer.next_event_line(self.index) {
-            None => None,
-            Some(event) => {
-                self.index += event.len();
-
-                Some(std::str::from_utf8(&event[..event.len() - 1]).unwrap())
-            }
-        }
+        self.buffer.write(&[EVENT_SEPARATOR])
     }
 }
 
 /// Wrapper around a [`TracingEventBuffer`](TracingEventBuffer) that can be shared between tracing and a consumer.
 #[derive(Debug)]
-pub struct SharedEventBuffer<B: TracingEventBuffer + 'static>(Arc<Mutex<B>>);
+pub(crate) struct SharedEventBuffer<B: TracingEventBuffer + 'static>(Arc<Mutex<B>>);
 impl<B: TracingEventBuffer> SharedEventBuffer<B> {
     pub fn new(inner: B) -> Self {
         Self(Arc::new(Mutex::new(inner)))
@@ -116,96 +99,3 @@ impl<'a, B: TracingEventBuffer + 'static> MakeWriter<'a> for SharedEventBuffer<B
     }
 }
 
-/// Inbounded buffer backed by `Vec<u8>`.
-pub struct VecEventBuffer {
-    /// Each event is terminated by a null byte. Otherwise there can be no null bytes in the strings because they are utf-8.
-    data: Vec<u8>,
-}
-impl VecEventBuffer {
-    pub fn new() -> Self {
-        Self { data: Vec::new() }
-    }
-}
-impl TracingEventBuffer for VecEventBuffer {
-    fn write(&mut self, data: &[u8]) {
-        self.data.extend(data.into_iter().copied())
-    }
-
-    fn next_event_line(&self, start: usize) -> Option<&'_ [u8]> {
-        if start >= self.data.len() {
-            return None;
-        }
-
-        let sub_data = &self.data[start..];
-        let end_offset = sub_data
-            .iter()
-            .position(|&b| b == b'\0')
-            .map(|p| p + 1)
-            .unwrap();
-
-        Some(&sub_data[..end_offset])
-    }
-
-    fn clear(&mut self) {
-        self.data.clear()
-    }
-}
-impl std::fmt::Debug for VecEventBuffer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "VecBuffer(<{} events, {} bytes>)",
-            self.data.iter().filter(|&&b| b == b'\0').count(),
-            self.data.len()
-        )
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::io::Write;
-
-    use super::{TracingEventBuffer, TracingEventBufferWriter, VecEventBuffer};
-
-    #[test]
-    fn test_event_buffer_writer() {
-        let mut buffer = VecEventBuffer::new();
-        let event =
-            "bananas are nice, this is a string\nwith a newline and 67 characters".to_string();
-
-        // this is the pattern of usage in tracing_subscriber
-        {
-            let mut writer = TracingEventBufferWriter::new(&mut buffer);
-            writer.write_all(event.as_bytes()).unwrap();
-        }
-        {
-            let mut writer = TracingEventBufferWriter::new(&mut buffer);
-            writer.write_all(event.as_bytes()).unwrap();
-        }
-        {
-            let mut writer = TracingEventBufferWriter::new(&mut buffer);
-            writer.write_all(event.as_bytes()).unwrap();
-        }
-
-        assert_eq!(buffer.data.len(), (event.len() + 1) * 3);
-        {
-            let events: Vec<&str> = buffer.events().collect();
-            assert_eq!(events, vec![event.as_str(), event.as_str(), event.as_str()]);
-        }
-
-        buffer.clear();
-        assert_eq!(buffer.data.len(), 0);
-    }
-
-    #[test]
-    fn test_vec_buffer_next_event_line() {
-        let mut buffer = VecEventBuffer::new();
-        assert_eq!(buffer.next_event_line(0), None);
-        assert_eq!(buffer.next_event_line(2), None);
-
-        buffer.write(b"abcd\0efgh\0");
-        assert_eq!(buffer.next_event_line(0).unwrap(), b"abcd\0");
-        assert_eq!(buffer.next_event_line(5).unwrap(), b"efgh\0");
-        assert_eq!(buffer.next_event_line(10), None);
-    }
-}

--- a/core/core/src/observability/buffer/ring.rs
+++ b/core/core/src/observability/buffer/ring.rs
@@ -1,0 +1,114 @@
+use std::collections::VecDeque;
+
+use super::{TracingEventBuffer, EVENT_SEPARATOR};
+
+pub struct RingEventBuffer {
+    data: VecDeque<u8>
+}
+impl RingEventBuffer {
+    pub fn new(size: usize) -> Self {
+        // ensure data.capacity is exactly size
+        let mut data = VecDeque::new();
+        data.reserve_exact(size);
+        
+        Self { data }
+    }
+
+    fn free_len(&self) -> usize {
+        self.data.capacity() - self.data.len()
+    }
+
+    fn pop_event(&mut self) -> impl Iterator<Item = u8> + '_ {
+        let (first, second) = self.data.as_slices();
+
+        let event_len = match first.into_iter().position(|&b| b == EVENT_SEPARATOR) {
+            Some(i) => i + 1,
+            None => match second.into_iter().position(|&b| b == EVENT_SEPARATOR) {
+                Some(i) => first.len() + i + 1,
+                None => unreachable!()
+            }
+        };
+
+        self.data.drain(0 .. event_len)
+    }
+}
+impl TracingEventBuffer for RingEventBuffer {
+    type RawParts = [(*const u8, usize); 2];
+    
+    fn write(&mut self, mut data: &[u8]) {
+		// if data is longer than internal capacity we only retain the last bytes of the input
+        if data.len() > self.data.capacity() {
+            data = &data[data.len() - self.data.capacity() ..];
+        } 
+        
+		// pop all previous events to make room for this new data
+        while data.len() > self.free_len() {
+            let _ = self.pop_event();
+        }
+
+		self.data.extend(data.into_iter().copied());
+    }
+
+    fn as_raw_parts(&self) -> Self::RawParts {
+        let (first, second) = self.data.as_slices();
+
+        [(first.as_ptr(), first.len()), (second.as_ptr(), second.len())]
+    }
+
+    fn clear(&mut self) {
+        self.data.clear();
+    }
+}
+impl std::fmt::Debug for RingEventBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "RingEventBuffer(<{} events, {} bytes>)",
+            self.data.iter().filter(|&&b| b == EVENT_SEPARATOR).count(),
+            self.data.len()
+        )
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use crate::observability::buffer::TracingEventBuffer;
+
+    use super::RingEventBuffer;
+
+	#[test]
+	fn test_ring_buffer_write_simple() {
+		let mut buffer = RingEventBuffer::new(10);
+		buffer.write(&[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+
+		assert_eq!(buffer.data.as_slices().0, &[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+	}
+
+    #[test]
+	fn test_ring_buffer_write_wrapping() {
+		let mut buffer = RingEventBuffer::new(10);
+		buffer.write(&[10, 11, 12, 0]);
+        buffer.write(&[13, 14, 15, 0]);
+
+		assert_eq!(buffer.data.as_slices().0, &[10, 11, 12, 0, 13, 14, 15, 0]);
+        assert_eq!(buffer.as_raw_parts()[0].1, 8);
+        assert_eq!(buffer.as_raw_parts()[1].1, 0);
+        assert_eq!(buffer.pop_event().collect::<Vec<_>>(), vec![10, 11, 12, 0]);
+
+        buffer.write(&[16, 17, 18, 0]);
+        buffer.write(&[19, 0]);
+        assert_eq!(buffer.data.as_slices().0, &[13, 14, 15, 0, 16, 17]);
+        assert_eq!(buffer.data.as_slices().1,&[18, 0, 19, 0]);
+        assert_eq!(buffer.as_raw_parts()[0].1, 6);
+        assert_eq!(buffer.as_raw_parts()[1].1, 4);
+        assert_eq!(buffer.pop_event().collect::<Vec<_>>(), vec![13, 14, 15, 0]);
+        assert_eq!(buffer.pop_event().collect::<Vec<_>>(), vec![16, 17, 18, 0]);
+        assert_eq!(buffer.pop_event().collect::<Vec<_>>(), vec![19, 0]);
+
+        assert!(buffer.data.as_slices().0.is_empty());
+        assert!(buffer.data.as_slices().1.is_empty());
+        assert_eq!(buffer.as_raw_parts()[0].1, 0);
+        assert_eq!(buffer.as_raw_parts()[1].1, 0);
+	}
+}

--- a/core/core/src/observability/buffer/vec.rs
+++ b/core/core/src/observability/buffer/vec.rs
@@ -1,0 +1,39 @@
+use crate::observability::buffer::EVENT_SEPARATOR;
+
+use super::TracingEventBuffer;
+
+/// Inbounded buffer backed by `Vec<u8>`.
+pub struct VecEventBuffer {
+    /// Each event is terminated by a null byte. Otherwise there can be no null bytes in the strings because they are utf-8.
+    data: Vec<u8>
+}
+impl VecEventBuffer {
+    pub fn new() -> Self {
+        Self { data: Vec::new() }
+    }
+}
+impl TracingEventBuffer for VecEventBuffer {
+    type RawParts = [(*const u8, usize); 1];
+
+    fn write(&mut self, data: &[u8]) {
+        self.data.extend(data.into_iter().copied())
+    }
+
+    fn as_raw_parts(&self) -> Self::RawParts {
+        [(self.data.as_ptr(), self.data.len())]
+    }
+
+    fn clear(&mut self) {
+        self.data.clear();
+    }
+}
+impl std::fmt::Debug for VecEventBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "VecBuffer(<{} events, {} bytes>)",
+            self.data.iter().filter(|&&b| b == EVENT_SEPARATOR).count(),
+            self.data.len()
+        )
+    }
+}

--- a/core/core/src/observability/mod.rs
+++ b/core/core/src/observability/mod.rs
@@ -44,7 +44,7 @@ fn init_tracing(
         .with_filter(
             EnvFilter::builder()
                 .with_default_directive(LevelFilter::WARN.into())
-                .with_env_var("OSDK_LOG")
+                .with_env_var("ONESDK_LOG")
                 .from_env_lossy(),
         );
 
@@ -65,7 +65,7 @@ fn init_tracing(
         .with_filter(
             EnvFilter::builder()
                 .with_default_directive(LevelFilter::OFF.into())
-                .with_env_var("OSDK_DEV_LOG")
+                .with_env_var("ONESDK_DEV_LOG")
                 .from_env_lossy(),
         );
 

--- a/core/core/src/observability/mod.rs
+++ b/core/core/src/observability/mod.rs
@@ -44,7 +44,7 @@ fn init_tracing(
         .with_filter(
             EnvFilter::builder()
                 .with_default_directive(LevelFilter::WARN.into())
-                .with_env_var("SF_LOG")
+                .with_env_var("OSDK_LOG")
                 .from_env_lossy(),
         );
 
@@ -65,7 +65,7 @@ fn init_tracing(
         .with_filter(
             EnvFilter::builder()
                 .with_default_directive(LevelFilter::OFF.into())
-                .with_env_var("SF_DEV_LOG")
+                .with_env_var("OSDK_DEV_LOG")
                 .from_env_lossy(),
         );
 

--- a/core/core/src/observability/mod.rs
+++ b/core/core/src/observability/mod.rs
@@ -1,0 +1,67 @@
+use tracing::metadata::LevelFilter;
+use tracing_subscriber::{
+    filter::FilterFn, fmt::format::json, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
+    Layer,
+};
+
+use self::buffer::{SharedEventBuffer, VecEventBuffer};
+
+pub mod buffer;
+
+pub fn init_tracing(
+    metrics_buffer: SharedEventBuffer<VecEventBuffer>,
+    developer_dump_buffer: SharedEventBuffer<VecEventBuffer>,
+) {
+    // we set up these layers:
+    // * user layer (@user) - output intended/relevant for users of the sdk
+    // * metrics layer (@metrics) - metrics sent to the dashboard
+    // * developer layer (everything) - output not relevant for normal users, but relevant when debugging and during development
+    // * dump layer (not @metrics) - output dumped after a panic, excluding metrics which are dumped separately
+
+    let user_layer = tracing_subscriber::fmt::layer()
+        .with_target(false)
+        .with_writer(std::io::stdout)
+        .with_filter(FilterFn::new(|metadata| {
+            metadata.target().starts_with("@user")
+        }))
+        .with_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::WARN.into())
+                .with_env_var("SF_LOG")
+                .from_env_lossy(),
+        );
+
+    let metrics_layer = tracing_subscriber::fmt::layer()
+        .event_format(
+            json()
+                .flatten_event(true)
+                .with_target(false)
+                .with_level(false),
+        )
+        .with_writer(metrics_buffer)
+        .with_filter(FilterFn::new(|metadata| {
+            metadata.target().starts_with("@metrics")
+        }));
+
+    let developer_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::OFF.into())
+                .with_env_var("SF_DEV_LOG")
+                .from_env_lossy(),
+        );
+
+    let developer_dump_layer = tracing_subscriber::fmt::layer()
+        .with_writer(developer_dump_buffer) // TODO: where to write? I'm thinking circular buffer which can be used to dump last logs in case of a panic
+        .with_filter(FilterFn::new(|metadata| {
+            !metadata.target().starts_with("@metrics")
+        }));
+
+    tracing_subscriber::registry()
+        .with(user_layer)
+        .with(metrics_layer)
+        .with(developer_layer)
+        .with(developer_dump_layer)
+        .init();
+}

--- a/core/core/src/sf_core.rs
+++ b/core/core/src/sf_core.rs
@@ -203,7 +203,7 @@ impl OneClientCore {
         let mut interpreter = JsInterpreter::new(MapStdImpl::new())?;
         // here we allow runtime stdlib replacement for development purposes
         // this might be removed in the future
-        match std::env::var("SF_REPLACE_MAP_STDLIB").ok() {
+        match std::env::var("OSDK_REPLACE_MAP_STDLIB").ok() {
             None => interpreter.eval_code("map_std.js", Self::MAP_STDLIB_JS),
             Some(path) => {
                 let replacement =

--- a/core/core/src/sf_core.rs
+++ b/core/core/src/sf_core.rs
@@ -14,8 +14,7 @@ use map_std::unstable::{
 };
 
 use crate::{
-    bindings::{MessageExchangeFfi, StreamExchangeFfi},
-    observability::buffer::TracingEventBuffer,
+    bindings::{MessageExchangeFfi, StreamExchangeFfi}
 };
 
 mod cache;
@@ -129,19 +128,6 @@ impl OneClientCore {
                     .map(|(k, v)| (k, self.map_value_to_host_value(v))),
             )),
         }
-    }
-
-    // TODO: use thiserror
-    pub fn send_metrics(&mut self, metrics: &mut impl TracingEventBuffer) -> anyhow::Result<()> {
-        let _span = tracing::trace_span!("send_metrics").entered();
-
-        for event in metrics.events() {
-            // TODO: send metric here
-            tracing::trace!("TODO: send metric \"{}\"", event);
-        }
-        metrics.clear();
-
-        Ok(())
     }
 
     pub fn perform(&mut self) -> Result<Result<HostValue, HostValue>, PerformExceptionError> {

--- a/core/core/src/sf_core.rs
+++ b/core/core/src/sf_core.rs
@@ -203,7 +203,7 @@ impl OneClientCore {
         let mut interpreter = JsInterpreter::new(MapStdImpl::new())?;
         // here we allow runtime stdlib replacement for development purposes
         // this might be removed in the future
-        match std::env::var("OSDK_REPLACE_MAP_STDLIB").ok() {
+        match std::env::var("ONESDK_REPLACE_MAP_STDLIB").ok() {
             None => interpreter.eval_code("map_std.js", Self::MAP_STDLIB_JS),
             Some(path) => {
                 let replacement =

--- a/core/core/src/sf_core.rs
+++ b/core/core/src/sf_core.rs
@@ -71,7 +71,14 @@ impl OneClientCore {
 
     // TODO: Use thiserror and define specific errors
     pub fn new(config: CoreConfiguration) -> anyhow::Result<Self> {
-        tracing::info!(config = ?config);
+        tracing::info!(target: "@user", config = ?config);
+
+        // { "timestamp": "<time>", "kind": "core-init", "cache_duration": 123 } 
+        tracing::info!(
+            target: "@metrics",
+            kind = "core-init",
+            cache_duration = config.cache_duration.as_secs()
+        );
 
         Ok(Self {
             document_cache: DocumentCache::new(config.cache_duration),
@@ -131,6 +138,15 @@ impl OneClientCore {
 
     pub fn perform(&mut self) -> Result<Result<HostValue, HostValue>, PerformExceptionError> {
         let perform_input = PerformInput::take_in(MessageExchangeFfi);
+
+        tracing::info!(
+            target: "@metrics",
+            kind = "perform-input",
+            profile_url = perform_input.profile_url,
+            provider_url = perform_input.provider_url,
+            map_url = perform_input.map_url,
+            usecase = perform_input.usecase
+        );
 
         self.document_cache.cache(&perform_input.profile_url)?;
         self.document_cache.cache(&perform_input.profile_url)?;

--- a/core/core/src/sf_core/cache.rs
+++ b/core/core/src/sf_core/cache.rs
@@ -78,7 +78,7 @@ impl DocumentCache {
                 {
                     Self::cache_http(&url)
                 } else {
-                    let url_base = std::env::var("OSDK_REGISTRY_URL")
+                    let url_base = std::env::var("ONESDK_REGISTRY_URL")
                         .unwrap_or("http://localhost:8321".to_string());
                     let url = format!("{}/{}.js", url_base, url);
 

--- a/core/core/src/sf_core/cache.rs
+++ b/core/core/src/sf_core/cache.rs
@@ -56,8 +56,7 @@ impl DocumentCache {
     }
 
     pub fn cache(&mut self, url: &str) -> Result<(), DocumentCacheError> {
-        let _span = tracing::span!(tracing::Level::DEBUG, "cache_document");
-        let _span = _span.enter();
+        let _span = tracing::debug_span!("cache_document").entered();
 
         tracing::debug!(url);
 
@@ -94,6 +93,13 @@ impl DocumentCache {
                 tracing::debug!(%utf8);
             }
         }
+
+        tracing::info!(
+            target: "@metrics",
+            kind = "cache-document",
+            url,
+            len = data.len()
+        );
 
         self.map.insert(
             url.to_string(),

--- a/core/core/src/sf_core/cache.rs
+++ b/core/core/src/sf_core/cache.rs
@@ -78,7 +78,7 @@ impl DocumentCache {
                 {
                     Self::cache_http(&url)
                 } else {
-                    let url_base = std::env::var("SF_REGISTRY_URL")
+                    let url_base = std::env::var("OSDK_REGISTRY_URL")
                         .unwrap_or("http://localhost:8321".to_string());
                     let url = format!("{}/{}.js", url_base, url);
 

--- a/core/core/src/sf_core/config.rs
+++ b/core/core/src/sf_core/config.rs
@@ -34,10 +34,10 @@ impl CoreConfiguration {
             (__internal parse usize) => { |v| v.parse::<usize>() };
         }
 
-        if let Some(v) = get_env!("OSDK_CONFIG_CACHE_DURATION", u64 "seconds")? {
+        if let Some(v) = get_env!("ONESDK_CONFIG_CACHE_DURATION", u64 "seconds")? {
             base.cache_duration = Duration::from_secs(v);
         }
-        if let Some(v) = get_env!("OSDK_CONFIG_DEV_DUMP_BUFFER_SIZE", usize "buffer size")? {
+        if let Some(v) = get_env!("ONESDK_CONFIG_DEV_DUMP_BUFFER_SIZE", usize "buffer size")? {
             base.developer_dump_buffer_size = v;
         }
 

--- a/core/core/src/sf_core/config.rs
+++ b/core/core/src/sf_core/config.rs
@@ -9,7 +9,7 @@ pub enum CoreConfigurationEnvError {
 #[derive(Debug)]
 pub struct CoreConfiguration {
     pub cache_duration: Duration,
-    pub developer_log_buffer_size: usize
+    pub developer_dump_buffer_size: usize
 }
 impl CoreConfiguration {
     pub fn from_env() -> Result<Self, CoreConfigurationEnvError> {
@@ -34,11 +34,11 @@ impl CoreConfiguration {
             (__internal parse usize) => { |v| v.parse::<usize>() };
         }
 
-        if let Some(v) = get_env!("SF_CONFIG_CACHE_DURATION", u64 "seconds")? {
+        if let Some(v) = get_env!("OSDK_CONFIG_CACHE_DURATION", u64 "seconds")? {
             base.cache_duration = Duration::from_secs(v);
         }
-        if let Some(v) = get_env!("SF_CONFIG_DEV_LOG_BUFFER_SIZE", usize "buffer size")? {
-            base.developer_log_buffer_size = v;
+        if let Some(v) = get_env!("OSDK_CONFIG_DEV_DUMP_BUFFER_SIZE", usize "buffer size")? {
+            base.developer_dump_buffer_size = v;
         }
 
         Ok(base)
@@ -48,7 +48,7 @@ impl Default for CoreConfiguration {
     fn default() -> Self {
         Self {
             cache_duration: Duration::from_secs(60 * 60),
-            developer_log_buffer_size: 1024 * 1024 // 1 MiB
+            developer_dump_buffer_size: 1024 * 1024 // 1 MiB
         }
     }
 }

--- a/core/core/src/sf_core/config.rs
+++ b/core/core/src/sf_core/config.rs
@@ -9,25 +9,37 @@ pub enum CoreConfigurationEnvError {
 #[derive(Debug)]
 pub struct CoreConfiguration {
     pub cache_duration: Duration,
+    pub developer_log_buffer_size: usize
 }
 impl CoreConfiguration {
     pub fn from_env() -> Result<Self, CoreConfigurationEnvError> {
         let mut base = Self::default();
 
-        // TODO: document configuration env vars somewhere
-        match std::env::var("SF_CONFIG_CACHE_DURATION")
-            .ok()
-            .map(|v| v.parse::<u64>())
-        {
-            None => (),
-            Some(Err(_)) => {
-                return Err(CoreConfigurationEnvError::InvalidVariableFormat(
-                    "SF_CONFIG_CACHE_DURATION".into(),
-                    "u64 (seconds)".into(),
-                ))
-            }
-            Some(Ok(v)) => base.cache_duration = Duration::from_secs(v),
-        };
+        macro_rules! get_env {
+            (
+                $env_name: literal, $parse_type: ident $parse_type_hint: literal
+            ) => {
+                match std::env::var($env_name).ok().map(get_env!(__internal parse $parse_type)) {
+                    None => Ok(None),
+                    Some(Err(_)) => Err(CoreConfigurationEnvError::InvalidVariableFormat(
+                        $env_name.into(),
+                        concat!(stringify!($parse_type), " (", $parse_type_hint, ")").into()
+                    )),
+                    Some(Ok(v)) => Ok(Some(v))
+                }
+            };
+
+            (__internal parse String) => { |v| Result::<String, std::convert::Infallible>::Ok(v) };
+            (__internal parse u64) => { |v| v.parse::<u64>() };
+            (__internal parse usize) => { |v| v.parse::<usize>() };
+        }
+
+        if let Some(v) = get_env!("SF_CONFIG_CACHE_DURATION", u64 "seconds")? {
+            base.cache_duration = Duration::from_secs(v);
+        }
+        if let Some(v) = get_env!("SF_CONFIG_DEV_LOG_BUFFER_SIZE", usize "buffer size")? {
+            base.developer_log_buffer_size = v;
+        }
 
         Ok(base)
     }
@@ -36,6 +48,7 @@ impl Default for CoreConfiguration {
     fn default() -> Self {
         Self {
             cache_duration: Duration::from_secs(60 * 60),
+            developer_log_buffer_size: 1024 * 1024 // 1 MiB
         }
     }
 }

--- a/core/core/src/sf_core/map_std_impl.rs
+++ b/core/core/src/sf_core/map_std_impl.rs
@@ -46,7 +46,7 @@ impl MapStdImpl {
 }
 impl MapStdUnstable for MapStdImpl {
     fn print(&mut self, message: &str) {
-        tracing::info!(map = %message);
+        tracing::info!(target: "@user", map = %message);
     }
 
     fn stream_read(&mut self, handle: Handle, buf: &mut [u8]) -> std::io::Result<usize> {

--- a/core/core/src/sf_core/profile_validator.rs
+++ b/core/core/src/sf_core/profile_validator.rs
@@ -34,7 +34,7 @@ impl ProfileValidator {
     pub fn new(profile: String, usecase: String) -> Result<Self, ProfileValidatorError> {
         let mut interpreter = JsInterpreter::new(MapStdImpl::new())?;
 
-        let validator_bytecode = match std::env::var("SF_REPLACE_PROFILE_VALIDATOR").ok() {
+        let validator_bytecode = match std::env::var("OSDK_REPLACE_PROFILE_VALIDATOR").ok() {
             None => interpreter.compile_code("profile_validator.js", Self::PROFILE_VALIDATOR_JS),
             Some(path) => {
                 let replacement = Fs::read_to_string(&path)

--- a/core/core/src/sf_core/profile_validator.rs
+++ b/core/core/src/sf_core/profile_validator.rs
@@ -34,7 +34,7 @@ impl ProfileValidator {
     pub fn new(profile: String, usecase: String) -> Result<Self, ProfileValidatorError> {
         let mut interpreter = JsInterpreter::new(MapStdImpl::new())?;
 
-        let validator_bytecode = match std::env::var("OSDK_REPLACE_PROFILE_VALIDATOR").ok() {
+        let validator_bytecode = match std::env::var("ONESDK_REPLACE_PROFILE_VALIDATOR").ok() {
             None => interpreter.compile_code("profile_validator.js", Self::PROFILE_VALIDATOR_JS),
             Some(path) => {
                 let replacement = Fs::read_to_string(&path)

--- a/core/host_to_core_std/src/abi/exchange.rs
+++ b/core/host_to_core_std/src/abi/exchange.rs
@@ -25,8 +25,7 @@ pub trait MessageExchange {
         &self,
         message: &M,
     ) -> Result<R, JsonMessageError> {
-        let _span = tracing::span!(tracing::Level::TRACE, "host/message_exchange");
-        let _span = _span.enter();
+        let _span = tracing::trace_span!("host/message_exchange").entered();
 
         let json_message =
             serde_json::to_string(message).map_err(JsonMessageError::SerializeFailed)?;

--- a/core/interpreter_js/src/core_to_map_bindings/mod.rs
+++ b/core/interpreter_js/src/core_to_map_bindings/mod.rs
@@ -24,7 +24,7 @@ macro_rules! link_into {
         $({
             let state = $state.clone();
             let fun = $context.wrap_callback(move |_context, this, args| {
-                let _span = tracing::span!(tracing::Level::TRACE, concat!("map/", $key)).entered();
+                let __span = tracing::trace_span!(concat!("map/", $key)).entered();
 
                 // SAFETY: this is safe because JSValueRef now contains a lifetime of the context, but the authors of the crate forgot to update `inner_value`
                 let this = unsafe { this.inner_value() };

--- a/examples/cloudflare_worker/src/index.ts
+++ b/examples/cloudflare_worker/src/index.ts
@@ -4,8 +4,8 @@ import { COMLINK_IMPORTS } from './comlinks';
 
 const client = new OneClient({
   env: {
-    SF_LOG: 'trace',
-    SF_CONFIG_CACHE_DURATION: '10'
+    OSDK_LOG: 'trace',
+    OSDK_CONFIG_CACHE_DURATION: '10'
   },
   assetsPath: 'superface',
   preopens: { ...COMLINK_IMPORTS }

--- a/examples/cloudflare_worker/src/index.ts
+++ b/examples/cloudflare_worker/src/index.ts
@@ -4,8 +4,8 @@ import { COMLINK_IMPORTS } from './comlinks';
 
 const client = new OneClient({
   env: {
-    OSDK_LOG: 'trace',
-    OSDK_CONFIG_CACHE_DURATION: '10'
+    ONESDK_LOG: 'trace',
+    ONESDK_CONFIG_CACHE_DURATION: '10'
   },
   assetsPath: 'superface',
   preopens: { ...COMLINK_IMPORTS }

--- a/host/js/README.md
+++ b/host/js/README.md
@@ -130,7 +130,7 @@ export default {
 
     const client = new OneClient({
       env: {
-        SF_LOG: 'info' // use `debug` or `trace` for development debugging
+        OSDK_LOG: 'info' // use `debug` or `trace` for development debugging
       },
       // preopens describes the virtual filesystem whith the OneClient file convention mapped to assets
       preopens: {

--- a/host/js/README.md
+++ b/host/js/README.md
@@ -130,7 +130,7 @@ export default {
 
     const client = new OneClient({
       env: {
-        OSDK_LOG: 'info' // use `debug` or `trace` for development debugging
+        ONESDK_LOG: 'info' // use `debug` or `trace` for development debugging
       },
       // preopens describes the virtual filesystem whith the OneClient file convention mapped to assets
       preopens: {

--- a/host/js/package.json
+++ b/host/js/package.json
@@ -23,7 +23,7 @@
     "prepack": "cp ../../LICENSE .",
     "postpack": "rm LICENSE",
     "build": "yarn clean && tsc -p tsconfig.json",
-    "test": "CORE_PATH=./assets/core-async.wasm OSDK_LOG=trace node --no-warnings --experimental-wasi-unstable-preview1 --experimental-vm-modules node_modules/.bin/jest"
+    "test": "CORE_PATH=./assets/core-async.wasm ONESDK_LOG=trace node --no-warnings --experimental-wasi-unstable-preview1 --experimental-vm-modules node_modules/.bin/jest"
   },
   "files": [
     "assets/**/*",

--- a/host/js/package.json
+++ b/host/js/package.json
@@ -23,7 +23,7 @@
     "prepack": "cp ../../LICENSE .",
     "postpack": "rm LICENSE",
     "build": "yarn clean && tsc -p tsconfig.json",
-    "test": "CORE_PATH=./assets/core-async.wasm SF_LOG=trace node --no-warnings --experimental-wasi-unstable-preview1 --experimental-vm-modules node_modules/.bin/jest"
+    "test": "CORE_PATH=./assets/core-async.wasm OSDK_LOG=trace node --no-warnings --experimental-wasi-unstable-preview1 --experimental-vm-modules node_modules/.bin/jest"
   },
   "files": [
     "assets/**/*",

--- a/host/js/src/common/app.ts
+++ b/host/js/src/common/app.ts
@@ -390,6 +390,9 @@ export class App implements AppContext {
         return await fn(...args);
       } catch (err: unknown) {
         // TODO: get metrics from core
+        // call tearndown which will detect that a panic has happened and attempt to dump developer log
+        // TODO: should this be under teardown or should we introduce a new function?
+        await this.core!.unsafeValue.teardownFn().catch(_ => undefined);
         // unsetting core, we can't ensure memory integrity
         this.core = undefined;
 


### PR DESCRIPTION
Use `tracing_subscriber` layers to implement 4 different event consumers:
* `@user` target which is intended for users to see what the sdk is doing
* `@metrics` target which formats metrics as JSON and stores them in a memory buffer
* developer target which logs everything, but is off by default
* developer dump target which logs everything but metrics and should be dumped _somewhere_ after the core panics