### PR TITLE
feat: update to quickjs-wasm-rs 1.0.0

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -372,8 +372,9 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "0.1.4"
-source = "git+https://github.com/Shopify/javy.git?tag=v0.6.0#bbb1d6033eee25b8003d34102032f887105d14fa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a318ed47e42082c11771620a1235231f34c10f775f4972dbc7753d4b07d8d568"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -383,8 +384,9 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-sys"
-version = "0.1.2"
-source = "git+https://github.com/Shopify/javy.git?tag=v0.6.0#bbb1d6033eee25b8003d34102032f887105d14fa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f72b064defce86eb257f5505ff22604f67d6b1036e995ac703cfdbe378e2df92"
 dependencies = [
  "bindgen",
  "cc",

--- a/core/interpreter_js/Cargo.toml
+++ b/core/interpreter_js/Cargo.toml
@@ -11,8 +11,7 @@ thiserror = { workspace = true }
 sf_std = { path = "../host_to_core_std", package = "host_to_core_std" }
 map_std = { path = "../core_to_map_std", package = "core_to_map_std" }
 
-quickjs-wasm-rs = { git = "https://github.com/Shopify/javy.git", tag = "v0.6.0", features = [] }
-# quickjs-wasm-sys = { git = "https://github.com/Shopify/javy.git", tag = "v0.6.0", features = [] }
+quickjs-wasm-rs = "1.0.0"
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/core/interpreter_js/src/core_to_map_bindings/mod.rs
+++ b/core/interpreter_js/src/core_to_map_bindings/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Context as AnyhowContext;
-use quickjs_wasm_rs::{Context, Value as JsValue};
+use quickjs_wasm_rs::{JSContextRef, JSValue, JSValueRef};
 
 /// Define `key`s in parent which call given `fn_impl(&mut state, context, this, args)`.
 ///
@@ -23,20 +23,24 @@ macro_rules! link_into {
     ) => {
         $({
             let state = $state.clone();
-            let fun = $context.wrap_callback(move |context, this, args| {
-                let __span = tracing::span!(tracing::Level::TRACE, concat!("map/", $key)).entered();
+            let fun = $context.wrap_callback(move |_context, this, args| {
+                let _span = tracing::span!(tracing::Level::TRACE, concat!("map/", $key)).entered();
 
-                let result = $fn_impl(state.borrow_mut().deref_mut(), context, this, args).map_err(anyhow::Error::from);
+                // SAFETY: this is safe because JSValueRef now contains a lifetime of the context, but the authors of the crate forgot to update `inner_value`
+                let this = unsafe { this.inner_value() };
+                let args: Vec<_> = unsafe { args.into_iter().map(|a| a.inner_value()).collect() };
+
+                let result = $fn_impl(state.borrow_mut().deref_mut(), this, &args).map_err(anyhow::Error::from);
 
                 if tracing::enabled!(tracing::Level::TRACE) {
                     use std::fmt::Write;
 
                     let mut buffer = String::new();
-                    write!(&mut buffer, "{}(this: {:?}", $key, JsValueDebug(&this)).unwrap();
+                    write!(&mut buffer, "{}(this: {:?}", $key, JSValueDebug::Ref(this)).unwrap();
                     for arg in args {
-                        write!(&mut buffer, ", {:?}", JsValueDebug(arg)).unwrap();
+                        write!(&mut buffer, ", {:?}", JSValueDebug::Ref(arg)).unwrap();
                     }
-                    write!(&mut buffer, ") -> {:?}", result.as_ref().map(JsValueDebug)).unwrap();
+                    write!(&mut buffer, ") -> {:?}", result.as_ref().map(JSValueDebug::Owned)).unwrap();
 
                     tracing::trace!("{}", buffer);
                 }
@@ -82,11 +86,11 @@ macro_rules! ensure_arguments {
 pub mod unstable;
 
 /// Returns the end of the `keys` chain by recursively traversing into objects, creating properties along the way if they don't exist.
-fn traverse_object(
-    context: &Context,
-    mut current: JsValue,
+fn traverse_object<'ctx>(
+    context: &'ctx JSContextRef,
+    mut current: JSValueRef<'ctx>,
     keys: &[&str],
-) -> anyhow::Result<JsValue> {
+) -> anyhow::Result<JSValueRef<'ctx>> {
     for &key in keys {
         current = match current.get_property(key) {
             Ok(value) if !value.is_undefined() => value,
@@ -106,15 +110,48 @@ fn traverse_object(
     Ok(current)
 }
 
-/// Newtype for formatting JsValues in a format suitable for debugging.
-struct JsValueDebug<'a>(&'a JsValue);
-impl std::fmt::Debug for JsValueDebug<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.0 {
-            x if x.is_str() => {
-                const MAX_SHOWN: usize = 300 - 2;
+/// Enum for formatting JsValues in a format suitable for debugging.
+enum JSValueDebug<'a> {
+    Ref(JSValueRef<'a>),
+    Owned(&'a JSValue)
+}
+impl<'a> JSValueDebug<'a> {
+    fn fmt_ref(rf: JSValueRef<'a>, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if rf.is_function() {
+            return write!(f, "<Function>");
+        }
+        if rf.is_big_int() {
+            return match rf.as_big_int_unchecked() {
+                Err(_) => write!(f, "{}", rf.as_str().unwrap()),
+                Ok(bint) => write!(f, "{:?}", bint)
+            }
+        }
+        if rf.is_array() || rf.is_object() {
+            // only show functions when formatted with `{:#?}`
+            let show_functions = f.alternate();
 
-                let string = x.as_str().unwrap();
+            let mut map = f.debug_map();
+            let mut properties = rf.properties().unwrap();
+            while let (Ok(Some(key)), Ok(value)) = (properties.next_key(), properties.next_value()) {
+                if value.is_function() && !show_functions {
+                    continue;
+                }
+
+                map.entry(&Self::Ref(key), &Self::Ref(value));
+            }
+            return map.finish();
+        }
+
+        match quickjs_wasm_rs::from_qjs_value(&rf) {
+            Err(err) => write!(f, "conversion error: {}", err),
+            Ok(v) => Self::fmt_owned(&v, f)
+        }
+    }
+
+    fn fmt_owned(value: &JSValue, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match value {
+            JSValue::String(string) => {
+                const MAX_SHOWN: usize = 300 - 2;
 
                 if string.len() > MAX_SHOWN && !f.alternate() {
                     write!(f, "{}..", &string[..MAX_SHOWN])
@@ -122,10 +159,9 @@ impl std::fmt::Debug for JsValueDebug<'_> {
                     write!(f, "{}", string)
                 }
             }
-            x if x.is_array_buffer() => {
+            JSValue::ArrayBuffer(bytes) => {
                 const MAX_SHOWN: usize = 5;
 
-                let bytes = x.as_bytes().unwrap();
                 write!(f, "<ArrayBuffer byteLength={} ", bytes.len())?;
                 if bytes.len() > MAX_SHOWN && !f.alternate() {
                     write!(f, "{:?}...>", &bytes[..bytes.len().min(MAX_SHOWN)])
@@ -133,29 +169,20 @@ impl std::fmt::Debug for JsValueDebug<'_> {
                     write!(f, "{:?}>", bytes)
                 }
             }
-            x if x.is_number() => write!(f, "{}", x.as_f64().unwrap()),
-            x if x.is_bool() => write!(f, "{}", x.as_bool().unwrap()),
-            x if x.is_null() => write!(f, "null"),
-            x if x.is_undefined() => write!(f, "undefined"),
-            x if x.is_big_int() => write!(f, "{:?}", x.as_big_int_unchecked().unwrap()),
-            x if x.is_function() => write!(f, "<Function>"),
-            x => {
-                // only show functions when formatted with `{:#?}`
-                let show_functions = f.alternate();
-
-                let mut properties = x.properties().unwrap();
-                let mut map = f.debug_map();
-                while let (Ok(Some(key)), Ok(value)) =
-                    (properties.next_key(), properties.next_value())
-                {
-                    if value.is_function() && !show_functions {
-                        continue;
-                    }
-
-                    map.entry(&JsValueDebug(&key), &JsValueDebug(&value));
-                }
-                return map.finish();
-            }
+            JSValue::Float(num) => write!(f, "{}", num),
+            JSValue::Int(num) => write!(f, "{}", num),
+            JSValue::Bool(b) => write!(f, "{}", b),
+            JSValue::Null => write!(f, "null"),
+            JSValue::Undefined => write!(f, "undefined"),
+            JSValue::Array(_) | JSValue::Object(_) => unreachable!()
+        }
+    }
+}
+impl std::fmt::Debug for JSValueDebug<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ref(rf) => Self::fmt_ref(*rf, f),
+            Self::Owned(v) => Self::fmt_owned(v, f)
         }
     }
 }

--- a/core/interpreter_js/src/core_to_map_bindings/unstable.rs
+++ b/core/interpreter_js/src/core_to_map_bindings/unstable.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, ops::DerefMut, rc::Rc};
 
 use anyhow::Context as AnyhowContext;
 use base64::Engine;
-use quickjs_wasm_rs::{JSContextRef, JSError, JSValueRef, JSValue};
+use quickjs_wasm_rs::{JSContextRef, JSError, JSValue, JSValueRef};
 
 use map_std::unstable::MapStdUnstable;
 use sf_std::MultiMap;

--- a/core/interpreter_js/src/lib.rs
+++ b/core/interpreter_js/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{cell::RefCell, ops::DerefMut, rc::Rc};
 
 use anyhow::Context as AnyhowContext;
-use thiserror::Error;
 use quickjs_wasm_rs::JSContextRef;
+use thiserror::Error;
 
 use map_std::MapStdFull;
 

--- a/core/interpreter_js/src/lib.rs
+++ b/core/interpreter_js/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{cell::RefCell, ops::DerefMut, rc::Rc};
 
 use anyhow::Context as AnyhowContext;
-use quickjs_wasm_rs::Context;
 use thiserror::Error;
+use quickjs_wasm_rs::JSContextRef;
 
 use map_std::MapStdFull;
 
@@ -22,13 +22,13 @@ pub enum JsInterpreterError {
 }
 
 pub struct JsInterpreter<S: MapStdFull + 'static> {
-    context: Context,
+    context: JSContextRef,
     #[allow(dead_code)]
     state: Rc<RefCell<S>>,
 }
 impl<S: MapStdFull + 'static> JsInterpreter<S> {
     pub fn new(state: S) -> Result<Self, JsInterpreterError> {
-        let mut context = Context::default();
+        let mut context = JSContextRef::default();
         let state = Rc::new(RefCell::new(state));
 
         // link ffi


### PR DESCRIPTION
Updates to newest published quickjs-wasm-rs version.

This comes with some breaking changes, so those are addressed. I also started an effort (https://github.com/bytecodealliance/javy/pull/395) to remove a friction point in `wrap_callback` which previously wasn't there.