### PR TITLE
fix(ci-cd): remove id-token permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,8 +170,6 @@ jobs:
     needs: [core]
     runs-on: ubuntu-latest
     if: inputs.host == 'python' || inputs.host == 'all'
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
     # Checkout
     - uses: actions/checkout@v3


### PR DESCRIPTION
Hopefully this is last failing part. And I actually don't know why this permission was added.