### PR TITLE
fix: document cache file not found errors

### DIFF
--- a/core/core/src/observability/metrics.rs
+++ b/core/core/src/observability/metrics.rs
@@ -55,6 +55,13 @@ pub mod __private {
     #[derive(Debug, Serialize)]
     pub struct PanicData<'a> {
         pub message: &'a str,
+        pub location: Option<PanicDataLocation<'a>>
+    }
+    #[derive(Debug, Serialize)]
+    pub struct PanicDataLocation<'a> {
+        pub file: &'a str,
+        pub line: u32,
+        pub column: u32
     }
 
     pub fn log_metric_event(event: impl Serialize) {
@@ -130,7 +137,8 @@ macro_rules! log_metric {
 
     (
         Panic
-        message = $message: expr
+        message = $message: expr,
+        location = $location: expr
         $(,)?
     ) => {
         {
@@ -152,7 +160,8 @@ macro_rules! log_metric {
                 event = ?Event::Panic {
                     occurred_at: &now,
                     data: PanicData {
-                        message: $message
+                        message: $message,
+                        location: $location.map(|(file, line, column)| PanicDataLocation { file, line, column })
                     }
                 }
             );

--- a/core/core/src/sf_core.rs
+++ b/core/core/src/sf_core.rs
@@ -72,7 +72,7 @@ impl<'a> PerformMetricsData<'a> {
         match self.provider {
             Some(provider) => provider,
             None => self
-                .profile_url
+                .provider_url
                 .split('/')
                 .last()
                 .and_then(|b| b.strip_suffix(".provider.json"))
@@ -270,7 +270,7 @@ impl OneClientCore {
             HostValue::None => MapValueObject::new(),
             _ => {
                 try_metrics!(Err(PerformExceptionError {
-                    error_core: "PerformInputParametersFormatError".to_string(),
+                    error_code: "PerformInputParametersFormatError".to_string(),
                     message: "Parameters must be an Object or None".to_string(),
                 }))
             }
@@ -331,7 +331,7 @@ impl OneClientCore {
                 let replacement =
                     try_metrics!(
                         Fs::read_to_string(&path).map_err(|err| PerformExceptionError {
-                            error_core: "ReplacementStdlibError".to_string(),
+                            error_code: "ReplacementStdlibError".to_string(),
                             message: format!("Failed to load replacement map_std: {}", err),
                         })
                     );

--- a/core/core/src/sf_core/exception.rs
+++ b/core/core/src/sf_core/exception.rs
@@ -5,7 +5,7 @@ use sf_std::unstable::perform::{PerformException, TakePerformInputError};
 use super::cache::DocumentCacheError;
 
 pub struct PerformExceptionError {
-    pub error_core: String,
+    pub error_code: String,
     pub message: String,
 }
 impl<PostProcessError: std::error::Error> From<DocumentCacheError<PostProcessError>>
@@ -13,7 +13,7 @@ impl<PostProcessError: std::error::Error> From<DocumentCacheError<PostProcessErr
 {
     fn from(value: DocumentCacheError<PostProcessError>) -> Self {
         PerformExceptionError {
-            error_core: "DocumentCacheError".to_string(),
+            error_code: "DocumentCacheError".to_string(),
             message: value.to_string(),
         }
     }
@@ -21,7 +21,7 @@ impl<PostProcessError: std::error::Error> From<DocumentCacheError<PostProcessErr
 impl From<PrepareSecurityMapError> for PerformExceptionError {
     fn from(value: PrepareSecurityMapError) -> Self {
         PerformExceptionError {
-            error_core: "PrepareSecurityMapError".to_string(),
+            error_code: "PrepareSecurityMapError".to_string(),
             message: value.to_string(),
         }
     }
@@ -29,7 +29,7 @@ impl From<PrepareSecurityMapError> for PerformExceptionError {
 impl From<JsInterpreterError> for PerformExceptionError {
     fn from(value: JsInterpreterError) -> Self {
         PerformExceptionError {
-            error_core: "JsInterpreterError".to_string(),
+            error_code: "JsInterpreterError".to_string(),
             message: value.to_string(),
         }
     }
@@ -37,7 +37,7 @@ impl From<JsInterpreterError> for PerformExceptionError {
 impl From<TakePerformInputError> for PerformExceptionError {
     fn from(value: TakePerformInputError) -> Self {
         PerformExceptionError {
-            error_core: "TakePerformInputError".to_string(),
+            error_code: "TakePerformInputError".to_string(),
             message: value.to_string(),
         }
     }
@@ -45,7 +45,7 @@ impl From<TakePerformInputError> for PerformExceptionError {
 impl From<PerformExceptionError> for PerformException {
     fn from(value: PerformExceptionError) -> Self {
         PerformException {
-            error_code: value.error_core,
+            error_code: value.error_code,
             message: value.message,
         }
     }

--- a/host/js/src/node/index.test.ts
+++ b/host/js/src/node/index.test.ts
@@ -85,5 +85,15 @@ describe('OneClient', () => {
       await expect(profile.getUseCase('CORE_PERFORM_PANIC').perform({}, { provider: 'localhost' })).rejects.toThrow(UnexpectedError);
       await expect(profile.getUseCase('CORE_PERFORM_TRUE').perform({}, { provider: 'localhost' })).resolves.toBe(true);
     });
+
+    test('profile file does not exist', async () => {
+      const client = new OneClient(clientOptions);
+
+      const profile = await client.getProfile('wasm-sdk/does-not-exist');
+      const usecase = profile.getUseCase('Example');
+      await expect(
+        () => usecase.perform({}, { provider: 'localhost' })
+      ).rejects.toThrow(UnexpectedError)
+    });
   });
 });

--- a/host/python/src/one_sdk/app.py
+++ b/host/python/src/one_sdk/app.py
@@ -133,7 +133,7 @@ class WasiApp:
 			self._perform_state.error = PerformError(message["error"])
 			return { "kind": "ok" }
 		elif message["kind"] == "perform-output-exception":
-			self._perform_state.exception = UnexpectedError(message["exception"]["error_core"], message["exception"]["message"])
+			self._perform_state.exception = UnexpectedError(message["exception"]["error_code"], message["exception"]["message"])
 			return { "kind": "ok" }
 		elif message["kind"] == "file-open":
 			try:

--- a/host/python/src/one_sdk/platform.py
+++ b/host/python/src/one_sdk/platform.py
@@ -46,6 +46,8 @@ class PythonFilesystem:
 		try:
 			# we always open the file in binary mode
 			file = cast(BinaryIO, open(path, mode))
+		except FileNotFoundError as e:
+			raise WasiError(WasiErrno.ENOENT) from e
 		except Exception as e:
 			# TODO: figure out what exceptions this can throw and map them to Wasi errnos
 			raise WasiError(WasiErrno.EINVAL) from e

--- a/host/python/tests/test_one_client.py
+++ b/host/python/tests/test_one_client.py
@@ -41,13 +41,28 @@ class TestOneClient(unittest.TestCase):
 		client._internal._core_path = os.path.abspath(os.path.join(__file__, "../../src/one_sdk/assets/test-core.wasm"))
 
 		profile = client.get_profile("wasm-sdk/example")
-		self.assertRaises(
-			UnexpectedError,
-			lambda: profile.get_usecase("CORE_PERFORM_PANIC").perform({}, provider = "localhost")
-		)
+		use_case = profile.get_usecase("CORE_PERFORM_PANIC")
+		with self.assertRaises(UnexpectedError):
+			use_case.perform({}, provider = "localhost")
 		self.assertTrue(
 			profile.get_usecase("CORE_PERFORM_TRUE").perform({}, provider = "localhost")
 		)
+	
+	def test_profile_file_does_not_exist(self):
+		client = OneClient(assets_path = ASSETS_PATH, superface_api_url = "superface.localhost")
+		profile = client.get_profile("wasm-sdk/does-not-exist")
+		use_case = profile.get_usecase("Example")
+		with self.assertRaises(UnexpectedError) as cm:
+			use_case.perform({}, provider = "localhost")
+		self.assertTrue("No such file or directory" in cm.exception.message)
+
+	def test_provider_file_does_not_exist(self):
+		client = OneClient(assets_path = ASSETS_PATH, superface_api_url = "superface.localhost")
+		profile = client.get_profile("wasm-sdk/example")
+		use_case = profile.get_usecase("Example")
+		with self.assertRaises(UnexpectedError) as cm:
+			use_case.perform({}, provider = "does-not-exist")
+		self.assertTrue("No such file or directory" in cm.exception.message)
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
* if a profile file was not found two things happened
  * the error generated was not correctly propagated to the host
  * the bad path was triggering another bug, causing recovery to crash
* also added more information into the PanicData metric to improve usefulness of dev log
