### PR TITLE
feat: improve js map stacktrace

### DIFF
--- a/core/interpreter_js/src/lib.rs
+++ b/core/interpreter_js/src/lib.rs
@@ -76,14 +76,15 @@ impl<S: MapStdFull + 'static> JsInterpreter<S> {
         Ok(())
     }
 
-    pub fn run(&mut self, code: &str, usecase: &str) -> Result<(), JsInterpreterError> {
+    pub fn run(&mut self, name: &str, code: &str, usecase: &str) -> Result<(), JsInterpreterError> {
         if code.len() == 0 {
             return Err(JsInterpreterError::EvalCodeEmpty);
         }
+        
+        self.eval_code(name, &code)?;
 
-        let bundle = format!("{}\n\n_start('{}');", code, usecase);
-
-        self.eval_code("map.js", &bundle)?;
+        let entry = format!("_start('{}');", usecase);
+        self.eval_code("", &entry)?;
 
         Ok(())
     }


### PR DESCRIPTION
* take map filename from the url and send it to the interpreter to be included in a potential stacktrace
* in the future the map name should be taken from the map manifest

related to #66

stacktrace example (python)
```
one_sdk.error.UnexpectedError: JsInterpreterError: Code evaluation failed: Uncaught ReferenceError: 'console' is not defined
    at Example (wasm-sdk.example.localhost.map.js:13)
    at _start (map_std.js:373)
    at <eval> ()
```