### PR TITLE
docs: Replace refs to Discord w/ GH Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Website](https://superface.ai) | [Get Started](https://superface.ai/docs/getting-started) | [Documentation](https://superface.ai/docs) | [Discord](https://sfc.is/discord) | [Twitter](https://twitter.com/superfaceai) | [Support](https://superface.ai/support)
+[Website](https://superface.ai) | [Get Started](https://superface.ai/docs/getting-started) | [Documentation](https://superface.ai/docs) | [GitHub Discussions](https://sfc.is/discussions) | [Twitter](https://twitter.com/superfaceai) | [Support](https://superface.ai/support)
 
 <img src="https://github.com/superfaceai/one-sdk/raw/main/docs/LogoGreen.png" alt="Superface" width="100" height="100">
 
@@ -8,7 +8,7 @@
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/superfaceai/one-sdk/ci_cd.yml)](https://github.com/superfaceai/one-sdk/actions/workflows/ci_cd.yml)
 [![license](https://img.shields.io/npm/l/@superfaceai/one-sdk)](LICENSE)
-[![Discord](https://img.shields.io/discord/819563244418105354?logo=discord&logoColor=fff)](https://sfc.is/discord)
+[![GitHub Discussions](https://img.shields.io/github/discussions/superfaceai/.github?logo=github&logoColor=fff)](https://github.com/orgs/superfaceai/discussions)
 
 This is a new implementation of [OneSDK for Node.js](https://github.com/superfaceai/one-sdk-js) using WebAssembly under the hood. Which allows us to give users OneSDK in their favorite language.
 
@@ -23,12 +23,13 @@ This will require to have Development requirements installed. In case of buildin
 ### Environment variables
 
 The OneSDK uses these environment variables:
-* `ONESDK_LOG=warn` - controls the level of logging intended for users. Set to `trace` to log everything intended for users. See [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax.
-* `ONESDK_REGISTRY_URL=http://localhost:8321` - Superface registry base URL
-* `ONESDK_CONFIG_CACHE_DURATION=3600` - duration in seconds of how long to cache documents (profiles, maps, providers) before downloading or reading them from the file system again
-* `ONESDK_CONFIG_DEV_DUMP_BUFFER_SIZE=1048576` - size of the developer log dump ring buffer
-* `ONESDK_DEV_LOG=off` - controls the level of logging intended for developers. Set to `trace` to see everything that is logged, including user log and metrics. See [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax.
-* `ONESDK_REPLACE_MAP_STDLIB=` - path to replacement map stdlib, intended for development only, may be removed at any time
+
+- `ONESDK_LOG=warn` - controls the level of logging intended for users. Set to `trace` to log everything intended for users. See [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax.
+- `ONESDK_REGISTRY_URL=http://localhost:8321` - Superface registry base URL
+- `ONESDK_CONFIG_CACHE_DURATION=3600` - duration in seconds of how long to cache documents (profiles, maps, providers) before downloading or reading them from the file system again
+- `ONESDK_CONFIG_DEV_DUMP_BUFFER_SIZE=1048576` - size of the developer log dump ring buffer
+- `ONESDK_DEV_LOG=off` - controls the level of logging intended for developers. Set to `trace` to see everything that is logged, including user log and metrics. See [tracing_subscriber directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) for full syntax.
+- `ONESDK_REPLACE_MAP_STDLIB=` - path to replacement map stdlib, intended for development only, may be removed at any time
 
 ## Supported languages
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,9 +10,9 @@ We are glad that you are interested in Superface in the way of contributing. We 
 
 ## Need help?
 
-If you have any question about this project (for example, how to use it) or if you just need some clarification about anything, please [open an issue](https://github.com/superfaceai/one-sdk/issues/new/choose) or ask on the [Discord server](https://sfc.is/discord). Alternatively check the [Support page](https://superface.ai/support) for other ways how to reach us.
+If you have any question about this project (for example, how to use it) or if you just need some clarification about anything, please [open an issue](https://github.com/superfaceai/one-sdk/issues/new/choose) or check the [Support page](https://superface.ai/support) for other ways how to reach us.
 
-## Help the community 
+## Help the community
 
 1. [Report a Bug](#contribute-by-reporting-bugs)
 2. [Contribute to the Documentation](#contribute-to-the-documentation)
@@ -46,7 +46,8 @@ Follow these steps:
 ### Development requirements
 
 macOS:
-```
+
+```shell
 # Core dependencies
 brew install docker
 # or dependencies locally

--- a/host/javascript/README.md
+++ b/host/javascript/README.md
@@ -1,4 +1,4 @@
-[Website](https://superface.ai) | [Get Started](https://superface.ai/docs/getting-started) | [Documentation](https://superface.ai/docs) | [Discord](https://sfc.is/discord) | [Twitter](https://twitter.com/superfaceai) | [Support](https://superface.ai/support)
+[Website](https://superface.ai) | [Get Started](https://superface.ai/docs/getting-started) | [Documentation](https://superface.ai/docs) | [GitHub Discussions](https://sfc.is/discussions) | [Twitter](https://twitter.com/superfaceai) | [Support](https://superface.ai/support)
 <br />
 <br />
 <img src="https://github.com/superfaceai/one-sdk/raw/main/docs/LogoGreen.png" alt="Superface" width="100" height="100">
@@ -9,9 +9,8 @@
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/superfaceai/one-sdk/ci_cd.yml)](https://github.com/superfaceai/one-sdk/actions/workflows/ci_cd.yml)
 [![license](https://img.shields.io/npm/l/@superfaceai/one-sdk)](LICENSE)
-[![Discord](https://img.shields.io/discord/819563244418105354?logo=discord&logoColor=fff)](https://sfc.is/discord)
+[![GitHub Discussions](https://img.shields.io/github/discussions/superfaceai/.github?logo=github&logoColor=fff)](https://github.com/orgs/superfaceai/discussions)
 [![npm](https://img.shields.io/npm/v/@superfaceai/one-sdk/beta.svg)](https://www.npmjs.com/package/@superfaceai/one-sdk/v/beta)
-
 
 `OneClient` is a universal API client which provides an unparalleled developer experience for every HTTP API. It enhances resiliency to API changes, and comes with built-in integration monitoring and provider failover.
 
@@ -22,7 +21,7 @@ For more details about Superface, visit [How it Works](https://superface.ai/how-
 - [Superface website](https://superface.ai)
 - [Get Started](https://superface.ai/docs/getting-started)
 - [Documentation](https://superface.ai/docs)
-- [Discord](https://sfc.is/discord)
+- [Support](https://superface.ai/support)
 
 ## Install
 
@@ -35,6 +34,7 @@ npm install @superfaceai/one-sdk@beta
 ## Setup
 
 OneClient uses three files (also called Comlink) which together make the integration:
+
 - **Profile** - describe business capabilities apart from the implementation details, what is expected as input and what will be the result. Profile name have optional scope before `/` and required name `[scope/]<name>`
 - **Provider** - Define a provider's API services and security schemes to use in a Comlink Map
 - **Map** - describe implementation details for fulfilling a business capability from a Comlink Profile
@@ -60,6 +60,7 @@ As an example, lets send an email with [Mailchimp](https://github.com/superfacea
 4. Add the map. Map connects profile and provider, so the filename is consists of both as well `communication.send-email.mailchimp.map.js`.
 
 The final structure should look like this:
+
 ```
 .
 └── superface/
@@ -73,29 +74,35 @@ The final structure should look like this:
 Create `index.mjs` file with following content and update:
 
 ```js
-import { OneClient, PerformError, UnexpectedError } from '@superfaceai/one-sdk/node';
+import {
+  OneClient,
+  PerformError,
+  UnexpectedError,
+} from '@superfaceai/one-sdk/node';
 
 const client = new OneClient();
 const profile = await client.getProfile('<profileName>');
 
 try {
-  const result = await profile.getUseCase('<usecaseName>').perform({
+  const result = await profile.getUseCase('<usecaseName>').perform(
+    {
       // Input parameters as defined in profile:
-      '<key>': '<value>'
+      '<key>': '<value>',
     },
     {
       provider: '<providerName>',
       parameters: {
         // Provider specific integration parameters:
-        '<integrationParameterName>': '<integrationParameterValue>'
+        '<integrationParameterName>': '<integrationParameterValue>',
       },
       security: {
         // Provider specific security values:
         '<securityValueId>': {
           // Security values as described in provider or on profile page
-        }
-      }
-    });
+        },
+      },
+    }
+  );
 } catch (e) {
   if (e instanceof PerformError) {
     console.log('ERROR RESULT:', e.errorResult);
@@ -188,9 +195,11 @@ Check full demo with [Shopify](https://github.com/superfaceai/demo-cloudflare-sh
 The next-gen OneSDK is still in beta stage and several features are not yet implemented. We welcome any and all feedback. The current limitations include:
 
 - OneSDK Client can't be instantiated in the global scope
+
   - We discovered Cloudflare is not allowing synchronisation between requests. We need to make sure, that two different requests are not accessing OneSDK Core at the same time. [The problem](https://zuplo.com/blog/the-script-will-never-generate-a-response-on-cloudflare-workers).
- 
+
 - Build-time integrations only
+
   - Currently the maps (integration glue) needs to be bundled with the worker at the build time
   - Future OneSDK will be fetching the maps at the runtime to enable dynamic healing and recovery
 

--- a/host/python/README.md
+++ b/host/python/README.md
@@ -1,4 +1,4 @@
-[Website](https://superface.ai) | [Get Started](https://superface.ai/docs/getting-started) | [Documentation](https://superface.ai/docs) | [Discord](https://sfc.is/discord) | [Twitter](https://twitter.com/superfaceai) | [Support](https://superface.ai/support)
+[Website](https://superface.ai) | [Get Started](https://superface.ai/docs/getting-started) | [Documentation](https://superface.ai/docs) | [GitHub Discussions](https://sfc.is/discussions) | [Twitter](https://twitter.com/superfaceai) | [Support](https://superface.ai/support)
 <br />
 <br />
 <img src="https://github.com/superfaceai/one-sdk/raw/main/docs/LogoGreen.png" alt="Superface" width="100" height="100">
@@ -9,7 +9,7 @@
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/superfaceai/one-sdk/ci_cd.yml)](https://github.com/superfaceai/one-sdk/actions/workflows/ci_cd.yml)
 [![license](https://img.shields.io/npm/l/@superfaceai/one-sdk)](LICENSE)
-[![Discord](https://img.shields.io/discord/819563244418105354?logo=discord&logoColor=fff)](https://sfc.is/discord)
+[![GitHub Discussions](https://img.shields.io/github/discussions/superfaceai/.github?logo=github&logoColor=fff)](https://github.com/orgs/superfaceai/discussions)
 [![npm](https://img.shields.io/pypi/v/one-sdk)](https://pypi.org/project/one-sdk/)
 
 `OneClient` is a universal API client which provides an unparalleled developer experience for every HTTP API. It enhances resiliency to API changes, and comes with built-in integration monitoring and provider failover.
@@ -21,7 +21,7 @@ For more details about Superface, visit [How it Works](https://superface.ai/how-
 - [Superface website](https://superface.ai)
 - [Get Started](https://superface.ai/docs/getting-started)
 - [Documentation](https://superface.ai/docs)
-- [Discord](https://sfc.is/discord)
+- [Support](https://superface.ai/support)
 
 ## Install
 
@@ -34,6 +34,7 @@ python3 -m pip install one-sdk
 ## Setup
 
 OneClient uses three files (also called Comlink) which together make the integration:
+
 - **Profile** - describe business capabilities apart from the implementation details, what is expected as input and what will be the result. Profile name have optional scope before `/` and required name `[scope/]<name>`
 - **Provider** - Define a provider's API services and security schemes to use in a Comlink Map
 - **Map** - describe implementation details for fulfilling a business capability from a Comlink Profile
@@ -59,6 +60,7 @@ As an example, lets send an email with [Mailchimp](https://github.com/superfacea
 4. Add the map. Map connects profile and provider, so the filename is consists of both as well `communication.send-email.mailchimp.map.js`.
 
 The final structure should look like this:
+
 ```
 .
 └── superface/
@@ -91,7 +93,7 @@ try:
         parameters = {
             '<integrationParameterName>': '<integrationParameterValue>'
         },
-        security = { 
+        security = {
             # Provider specific security values:
             '<securityValueId>': {
                 # Security values as described in provider or on profile page


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

Update all READMEs and contributing guide to replace references to Discord with GitHub discussions and support page.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk/blob/main/SECURITY.md) is correct.
- [ ] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk/blob/main/docs/CONTRIBUTING.md) document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All tests passed.
