### PR TITLE
Generate JSON Schemas from Rust data structures

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -216,6 +216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +609,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "schemas"
+version = "0.1.0"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +659,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.5",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,7 +3,8 @@ members = [
 	"core",
 	"host_to_core_std",
 	"core_to_map_std",
-	"interpreter_js"
+	"interpreter_js",
+	"schemas"
 ]
 
 [workspace.dependencies]
@@ -17,6 +18,8 @@ regex = { version = "1" }
 url = { version = "2" }
 
 tracing = { version = "0.1" }
+
+schemars = "0.8.12"
 
 [profile.release]
 opt-level = "s"

--- a/core/schemas/cargo.toml
+++ b/core/schemas/cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "schemas"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[features]
+default = []
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+

--- a/core/schemas/src/main.rs
+++ b/core/schemas/src/main.rs
@@ -1,0 +1,10 @@
+use schemars::schema_for;
+
+use crate::security_values::SecurityValues;
+
+mod security_values;
+
+fn main() {
+    let schema = schema_for!(SecurityValues);
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+}

--- a/core/schemas/src/security_values.rs
+++ b/core/schemas/src/security_values.rs
@@ -1,0 +1,62 @@
+// Failed pretty fast on HashMap support: https://github.com/GREsau/schemars/issues/124
+
+/*
+{
+  "type": "object",
+  "patternProperties": {
+    "^[a-z][_\\-a-z]*$": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "token": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "apikey": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}
+*/
+
+//use std::collections::HashMap;
+
+//pub type SecurityValues = HashMap<String, SecurityValue>;
+
+use schemars::JsonSchema;
+
+#[derive(JsonSchema)]
+pub struct SecurityValues {
+    pub name: SecurityValue,
+}
+
+#[derive(JsonSchema)]
+pub enum SecurityValue {
+    Apikey { apikey: String },
+    Token { token: String },
+    Basic { username: String, password: String },
+}

--- a/core/schemas/src/security_values.rs
+++ b/core/schemas/src/security_values.rs
@@ -1,4 +1,4 @@
-// Failed pretty fast on HashMap support: https://github.com/GREsau/schemars/issues/124
+// https://github.com/GREsau/schemars/issues/124
 
 /*
 {
@@ -43,15 +43,62 @@
 }
 */
 
-//use std::collections::HashMap;
+use core::fmt;
+use std::collections::BTreeMap;
 
-//pub type SecurityValues = HashMap<String, SecurityValue>;
+use schemars::{
+    schema::{InstanceType, ObjectValidation, Schema, SchemaObject, StringValidation},
+    schema_for, JsonSchema,
+};
 
-use schemars::JsonSchema;
+#[derive(Debug, Eq, Ord)]
+pub struct Id {
+    value: String,
+}
+impl From<&str> for Id {
+    fn from(s: &str) -> Id {
+        Id {
+            value: s.to_owned(),
+        }
+    }
+}
+impl Into<Id> for String {
+    fn into(self) -> Id {
+        Id { value: self }
+    }
+}
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+impl PartialEq for Id {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+impl PartialOrd for Id {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
 
-#[derive(JsonSchema)]
-pub struct SecurityValues {
-    pub name: SecurityValue,
+impl JsonSchema for Id {
+    fn schema_name() -> String {
+        "Id".to_owned()
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            string: Some(Box::new(StringValidation {
+                pattern: Some(r"^[a-z][_\-a-z]*$".to_owned()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
 }
 
 #[derive(JsonSchema)]
@@ -59,4 +106,63 @@ pub enum SecurityValue {
     Apikey { apikey: String },
     Token { token: String },
     Basic { username: String, password: String },
+}
+
+pub struct SecurityValues {
+    map: BTreeMap<Id, SecurityValue>,
+}
+impl SecurityValues {
+    pub fn new() -> Self {
+        Self {
+            map: BTreeMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, key: Id, value: SecurityValue) {
+        self.map.insert(key, value);
+    }
+}
+impl JsonSchema for SecurityValues {
+    fn schema_name() -> String {
+        "SecurityValues".to_owned()
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let mut pattern_properties = BTreeMap::new();
+        pattern_properties.insert(
+            schema_for!(Id).schema.string.unwrap().pattern.unwrap(),
+            Schema::Object(schema_for!(SecurityValue).schema),
+        );
+
+        SchemaObject {
+            instance_type: Some(InstanceType::Object.into()),
+            object: Some(Box::new(ObjectValidation {
+                pattern_properties,
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use schemars::schema_for;
+
+    use super::{Id, SecurityValue, SecurityValues};
+
+    #[test]
+    fn basics() {
+        let mut sec_vals = SecurityValues::new();
+        sec_vals.insert(
+            "example_api_key".into(),
+            SecurityValue::Apikey {
+                apikey: "my api key".to_owned(),
+            },
+        );
+
+        let schema = schema_for!(SecurityValues);
+        println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+    }
 }


### PR DESCRIPTION
Looks patter_properties are not supported well in [Schemars](https://github.com/GREsau/schemars/issues/124), So I defined custom types. 

The point of this PR is to illustrate it can be somehow achieved to generate desired schema by manually implementing it for custom types, still the question is if we can align it with [SecurityMap](https://github.com/superfaceai/one-sdk/blob/main/core/core_to_map_std/src/unstable/security.rs#L79C5-L79C5) 

