### PR TITLE
fix: JsValueDebug cutting string at non-char boundary

### DIFF
--- a/core/core/src/observability/mod.rs
+++ b/core/core/src/observability/mod.rs
@@ -71,25 +71,6 @@ fn init_tracing(
                 .from_env_lossy(),
         );
 
-    // let metrics_layer = tracing_subscriber::fmt::layer()
-    //     .event_format(
-    //         format::json()
-    //             .without_time() // we add our own time as a field
-    //             .with_level(false)
-    //             .flatten_event(true)
-    //             .with_target(false)
-    //             .with_file(false)
-    //             .with_line_number(false)
-    //             .with_current_span(false)
-    //             .with_span_list(false)
-    //             .with_thread_names(false)
-    //             .with_thread_ids(false),
-    //     )
-    //     .with_writer(metrics_buffer)
-    //     .with_filter(FilterFn::new(|metadata| {
-    //         metadata.target().starts_with("@metrics")
-    //     }));
-
     let developer_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
         .with_filter(
@@ -103,14 +84,10 @@ fn init_tracing(
         .event_format(
             format::format().with_ansi(false), // disable ansi colors because this will usually go into a file
         )
-        .with_writer(developer_dump_buffer)
-        .with_filter(FilterFn::new(|metadata| {
-            !metadata.target().starts_with("@metrics")
-        }));
+        .with_writer(developer_dump_buffer);
 
     tracing_subscriber::registry()
         .with(user_layer)
-        // .with(metrics_layer)
         .with(developer_layer)
         .with(developer_dump_layer)
         .init();


### PR DESCRIPTION
* JsValueDebug was cutting long strings at non-char boundaries accidentally
* dev log dump now includes `@metrics` target

There was an issue with the JsValueDebug printing that if the string was too long and was cut to MAX_SHOWN len for logging this could fall inside an UTF8 char and cause a panic.

Also panics were not being included in dev log dump.