### PR TITLE
Move json schema test next to schemas

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -499,6 +499,7 @@ dependencies = [
 name = "json_schemas"
 version = "0.1.0"
 dependencies = [
+ "jsonschema",
  "serde_json",
  "serde_yaml",
 ]

--- a/core/core/src/sf_core/json_schema_validator.rs
+++ b/core/core/src/sf_core/json_schema_validator.rs
@@ -83,8 +83,6 @@ impl JsonSchemaValidator {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
-
     use super::*;
     use serde::Deserialize;
     use serde_json::json;
@@ -145,61 +143,5 @@ mod test {
             validator.err().unwrap(),
             JsonSchemaValidatorError::SchemaError { .. }
         ));
-    }
-
-    #[test]
-    fn test_security_values_validator() {
-        const SECURITY_VALUES_SCHEMA: &str =
-            include_str!("../../assets/schemas/security_values.json"); // read higher
-
-        let security_validator = JsonSchemaValidator::new(
-            &serde_json::Value::from_str(&SECURITY_VALUES_SCHEMA).unwrap(),
-        )
-        .unwrap();
-
-        let result = security_validator.validate(
-            &HostValue::deserialize(&json!({
-                "my_basic": {
-                    "username": "username",
-                    "password": "password"
-                },
-                "my_token": {
-                    "token": "token"
-                },
-                "my_api_key": {
-                    "apikey": "api key"
-                }
-            }))
-            .unwrap(),
-        );
-        assert!(result.is_ok());
-
-        let result = security_validator.validate(
-            &HostValue::deserialize(&json!({
-                "security_config": {
-                    "unknown": "so invalid"
-                }
-            }))
-            .unwrap(),
-        );
-        assert!(result.is_err());
-
-        let result = security_validator.validate(
-            &HostValue::deserialize(&json!({
-                "partial_basic": {
-                    "username": "username"
-                }
-            }))
-            .unwrap(),
-        );
-        assert!(result.is_err());
-
-        let result = security_validator.validate(
-            &HostValue::deserialize(&json!({
-                "empty": {}
-            }))
-            .unwrap(),
-        );
-        assert!(result.is_err());
     }
 }

--- a/core/json_schemas/Cargo.toml
+++ b/core/json_schemas/Cargo.toml
@@ -7,3 +7,6 @@ publish = false
 [dependencies]
 serde_json = { workspace = true }
 serde_yaml = { version = "0.9" }
+
+[dev-dependencies]
+jsonschema = { workspace = true }

--- a/core/json_schemas/src/main.rs
+++ b/core/json_schemas/src/main.rs
@@ -35,12 +35,16 @@ fn translate(yaml_path: &std::path::PathBuf) {
     println!("Translating {:?}", yaml_path);
 
     let content = fs::read_to_string(&yaml_path).expect("Readable JSON schema in YAML format");
-    let yaml: serde_json::Value = serde_yaml::from_str(&content).expect("Valid YAML");
+    let json = translate_to_json(&content);
 
     let mut json_path = yaml_path.clone();
     json_path.set_extension("json");
-    let json = serde_json::to_string_pretty(&yaml).unwrap();
 
-    let mut file = fs::File::create(json_path.as_path()).expect("Writeble file");
+    let mut file = fs::File::create(json_path.as_path()).expect("Writable file");
     file.write_all(json.as_bytes()).unwrap();
+}
+
+pub fn translate_to_json(content: &str) -> String {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(content).expect("Valid YAML");
+    serde_json::to_string_pretty(&yaml).unwrap()
 }

--- a/core/json_schemas/src/schemas/security_values.json
+++ b/core/json_schemas/src/schemas/security_values.json
@@ -1,14 +1,16 @@
 {
+  "type": "object",
   "patternProperties": {
     "^[a-z][_\\-a-z]*$": {
+      "type": "object",
       "oneOf": [
         {
-          "additionalProperties": false,
+          "type": "object",
           "properties": {
-            "password": {
+            "username": {
               "type": "string"
             },
-            "username": {
+            "password": {
               "type": "string"
             }
           },
@@ -16,10 +18,10 @@
             "username",
             "password"
           ],
-          "type": "object"
+          "additionalProperties": false
         },
         {
-          "additionalProperties": false,
+          "type": "object",
           "properties": {
             "token": {
               "type": "string"
@@ -28,10 +30,10 @@
           "required": [
             "token"
           ],
-          "type": "object"
+          "additionalProperties": false
         },
         {
-          "additionalProperties": false,
+          "type": "object",
           "properties": {
             "apikey": {
               "type": "string"
@@ -40,11 +42,9 @@
           "required": [
             "apikey"
           ],
-          "type": "object"
+          "additionalProperties": false
         }
-      ],
-      "type": "object"
+      ]
     }
-  },
-  "type": "object"
+  }
 }

--- a/core/json_schemas/tests/common/mod.rs
+++ b/core/json_schemas/tests/common/mod.rs
@@ -1,0 +1,8 @@
+macro_rules! json_schema {
+    ($file:expr) => {{
+        let yaml_str = include_str!($file);
+        let yaml: serde_yaml::Value = serde_yaml::from_str(yaml_str).expect("Valid YAML");
+        let json = serde_json::to_value(&yaml).expect("Valid JSON");
+        jsonschema::JSONSchema::compile(&json).expect("Valid JSON Schema")
+    }};
+}

--- a/core/json_schemas/tests/security_values_test.rs
+++ b/core/json_schemas/tests/security_values_test.rs
@@ -1,0 +1,46 @@
+use serde_json::json;
+
+#[macro_use]
+mod common;
+
+#[test]
+fn test_security_values() {
+    let schema = json_schema!("../src/schemas/security_values.yaml");
+
+    let instance = json!({
+        "my_basic": {
+            "username": "username",
+            "password": "password"
+        },
+        "my_token": {
+            "token": "token"
+        },
+        "my_api_key": {
+            "apikey": "api key"
+        }
+    });
+    let result = schema.validate(&instance);
+    assert!(result.is_ok());
+
+    let instance = json!({
+        "security_config": {
+            "unknown": "so invalid"
+        }
+    });
+    let result = schema.validate(&instance);
+    assert!(result.is_err());
+
+    let instance = json!({
+        "partial_basic": {
+            "username": "username"
+        }
+    });
+    let result = schema.validate(&instance);
+    assert!(result.is_err());
+
+    let instance = json!({
+        "empty": {}
+    });
+    let result = schema.validate(&instance);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
When I was fixing Security Values validation, I realized, that testing schema as part of JSON Schema validator isn't best place. 

In this PR, I moved tests to the `json_schema` module.

The open question is, if tests should translate YAML to JSON, or just use JSON which is present.
