### PR TITLE
fix(host-javascript): properly export esm modules

### DIFF
--- a/host/javascript/package.json
+++ b/host/javascript/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@superfaceai/one-sdk",
   "version": "3.0.0-beta.3",
-  "main": "node/index.js",
+  "exports": {
+    "./node": "./node/index.js",
+    "./cloudflare": "./cloudflare/index.js"
+  },
   "type": "module",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
As I was updating examples for ValidationError I realised, we do have imports like this `@superfaceai/one-sdk/node`, but those didn't work. They required `@superfaceai/one-sdk/node/index.js`.

This PR corrects it, but the original way will work as well.