### PR TITLE
Exports must include `node/index.js` for backward compatibility

### DIFF
--- a/host/javascript/package.json
+++ b/host/javascript/package.json
@@ -3,7 +3,9 @@
   "version": "3.0.0-beta.3",
   "exports": {
     "./node": "./node/index.js",
-    "./cloudflare": "./cloudflare/index.js"
+    "./node/index.js": "./node/index.js",
+    "./cloudflare": "./cloudflare/index.js",
+    "./cloudflare/index.js": "./cloudflare/index.js"
   },
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Before I tested it, but obviously badly.

for backward compatibility `node/index.js` and `cloudflare/index.js` must be listed as well.