### PR TITLE
Publishing is separated from repository prepare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,175 +83,264 @@ jobs:
         with:
           name: core-wasm
           path: core/dist/core.wasm
-      # TODO: Changelog, commit taggin ands GitHub release 
+      # TODO: Changelog update create tag and GitHub release
 
-  host-javascript:
-    name: JavaScript Host
-    # when host-python is skipped this job should still run if inputs allow
-    # so we need to include a status check, then manually ensure core build didn't fail
-    # (see https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions)
-    needs: [core, host-python]
-    if: ${{ !cancelled() && (needs.core.result == 'success') && (inputs.host == 'js' || inputs.host == 'all') }}
-    runs-on: ubuntu-latest
-    steps:
-    # checkout
-    - uses: actions/checkout@v3
-    - name: Git configuration
-      run: |
-        git config --global user.email "bot@superface.ai"
-        git config --global user.name "GitHub Actions release workflow"
-    # setup
-    - uses: actions/setup-node@v3
-      with:
-        registry-url: https://registry.npmjs.org/
-        node-version: "18"
-        cache: yarn
-        cache-dependency-path: host/javascript/yarn.lock
-    - uses: actions/download-artifact@v3
-      with:
-        name: core-async-wasm
-        path: host/javascript/assets
-    # build
-    - name: Build host/javascript
-      working-directory: host/javascript
-      run: |
-        yarn install --frozen-lockfile
-        yarn build
-    # resolve release version
-    - name: Resolve release level
-      id: release-level
-      run: scripts/release-level.sh ${{ inputs.release-level }} ${{ inputs.release-kind }} >>$GITHUB_OUTPUT
-    - name: Resolve release version
-      id: release-version
-      run: scripts/release-version.sh ./host/javascript/VERSION ${{ steps.release-level.outputs.RELEASE_LEVEL }} ${{ steps.release-level.outputs.RELEASE_PREID }} >>$GITHUB_OUTPUT
-    # publish and push git
-    - name: Publish
-      working-directory: host/javascript
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPMJS_BOT_PAT }}
-      run: yarn publish --verbose --no-git-tag-version --access public --new-version ${{ steps.release-version.outputs.RELEASE_VERSION }} --tag ${{ steps.release-level.outputs.RELEASE_TAG }}
-    # Changelog
-    - name: Update changelog
-      uses: superfaceai/release-changelog-action@v1
-      if: ${{ steps.release-level.outputs.RELEASE_TAG == 'latest' }}
-      with:
-        path-to-changelog: host/javascript/CHANGELOG.md
-        version: ${{ steps.release-version.outputs.RELEASE_VERSION }}
-        operation: release
-    # Commit release changes
-    - name: Git configuration
-      run: |
-        git config --global user.email "bot@superface.ai"
-        git config --global user.name "GitHub Actions release workflow"
-    - name: Commit package.json, VERSION, CHANGELOG.md and create git tag
-      working-directory: host/javascript
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git add package.json VERSION CHANGELOG.md
-        git commit -m "chore: release host/javascript ${{ steps.release-version.outputs.RELEASE_VERSION }}"
-        git tag "js-v${{ steps.release-version.outputs.RELEASE_VERSION }}"
-        git push origin
-        git push origin --tags
-    # Create GitHub Release
-    - name: Get release version changelog
-      id: get-changelog
-      if: ${{ steps.release-level.outputs.RELEASE_TAG == 'latest' }}
-      uses: superfaceai/release-changelog-action@v1
-      with:
-        path-to-changelog: CHANGELOG.md
-        version: ${{ steps.release-version.outputs.RELEASE_VERSION }}
-        operation: read
-    - name: Update GitHub release documentation
-      uses: softprops/action-gh-release@v1
-      if: ${{ steps.release-level.outputs.RELEASE_TAG == 'latest' }}
-      with:
-        tag_name: "js-v${{ steps.release-version.outputs.RELEASE_VERSION }}"
-        body: ${{ steps.get-changelog.outputs.changelog }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  host-python:
-    name: Python Host
+  host-javascript-prepare:
+    name: Prepare JavaScript Host
     needs: [core]
-    if: inputs.host == 'python' || inputs.host == 'all'
+    if: ${{ inputs.host == 'js' || inputs.host == 'all' }}
     runs-on: ubuntu-latest
     steps:
-    # Checkout
-    - uses: actions/checkout@v3
-    # Setup
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.x"
-    # Download core wasm
-    - uses: actions/download-artifact@v3
-      with:
-        name: core-wasm
-        path: host/python/src/one_sdk/assets
-    - name: Install Python tools
-      run: python -m pip install build toml-cli
-    # Copy LICENSE
-    - name: Copy LICENSE
-      run: cp LICENSE host/python/LICENSE
-    # Resolve release version
-    - name: Resolve release level
-      id: release-level
-      run: scripts/release-level.sh ${{ inputs.release-level }} ${{ inputs.release-kind }} >>$GITHUB_OUTPUT
-    - name: Resolve release version
-      id: release-version
-      run: scripts/release-version.sh ./host/python/VERSION ${{ steps.release-level.outputs.RELEASE_LEVEL }} ${{ steps.release-level.outputs.RELEASE_PREID }} >>$GITHUB_OUTPUT
-    # Update version
-    - name: Update version
-      working-directory: host/python
-      run: toml set --toml-path pyproject.toml project.version  ${{ steps.release-version.outputs.RELEASE_VERSION }}
-    # Build
-    - name: Build host/python
-      working-directory: host/python
-      run: python -m build
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        packages-dir: host/python/dist
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-    # Changelog
-    - name: Update changelog
-      uses: superfaceai/release-changelog-action@v1
-      if: ${{ steps.release-level.outputs.RELEASE_TAG == 'latest' }}
-      with:
-        path-to-changelog: host/python/CHANGELOG.md
-        version: ${{ steps.release-version.outputs.RELEASE_VERSION }}
-        operation: release
-    # Commit release changes
-    - name: Git configuration
-      run: |
-        git config --global user.email "bot@superface.ai"
-        git config --global user.name "GitHub Actions release workflow"
-    - name: Commit pyproject.toml, VERSION, CHANGELOG.md and create git tag
-      working-directory: host/python
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git add pyproject.toml VERSION CHANGELOG.md
-        git commit -m "chore: release host/python ${{ steps.release-version.outputs.RELEASE_VERSION }}"
-        git tag "python-v${{ steps.release-version.outputs.RELEASE_VERSION }}"
-        git push origin
-        git push origin --tags
-    # Create GitHub Release
-    - name: Get release version changelog
-      id: get-changelog
-      if: ${{ steps.release-level.outputs.RELEASE_TAG == 'latest' }}
-      uses: superfaceai/release-changelog-action@v1
-      with:
-        path-to-changelog: CHANGELOG.md
-        version: ${{ steps.release-version.outputs.RELEASE_VERSION }}
-        operation: read
-    - name: Update GitHub release documentation
-      uses: softprops/action-gh-release@v1
-      if: ${{ steps.release-level.outputs.RELEASE_TAG == 'latest' }}
-      with:
-        tag_name: "python-v${{ steps.release-version.outputs.RELEASE_VERSION }}"
-        body: ${{ steps.get-changelog.outputs.changelog }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Setup
+      - uses: actions/checkout@v3
+      - name: Git configuration
+        run: |
+          git config --global user.email "bot@superface.ai"
+          git config --global user.name "GitHub Actions release workflow"
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: https://registry.npmjs.org/
+          node-version: "18"
+          cache: yarn
+          cache-dependency-path: host/javascript/yarn.lock
+      # Release version
+      - name: Resolve release level
+        id: release-level
+        run: scripts/release-level.sh ${{ inputs.release-level }} ${{ inputs.release-kind }} >>$GITHUB_OUTPUT
+      - name: Resolve release version
+        id: release-version
+        run: scripts/release-version.sh ./host/javascript/VERSION ./host/javascript/VERSION ${{ steps.release-level.outputs.RELEASE_LEVEL }} ${{ steps.release-level.outputs.RELEASE_PREID }} >>$GITHUB_OUTPUT
+      # Build
+      - uses: actions/download-artifact@v3
+        with:
+          name: core-async-wasm
+          path: host/javascript/assets
+      - name: Copy LICENSE
+        run: cp LICENSE host/javascript/LICENSE
+      - name: Build host/javascript
+        working-directory: host/javascript
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+      # Changelog
+      - name: Update changelog
+        uses: superfaceai/release-changelog-action@v1
+        if: ${{ steps.release-level.outputs.RELEASE_TAG == 'latest' }}
+        with:
+          path-to-changelog: host/javascript/CHANGELOG.md
+          version: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+          operation: release
+      # Commit release changes
+      - name: Git configuration
+        run: |
+          git config --global user.email "bot@superface.ai"
+          git config --global user.name "GitHub Actions release workflow"
+      - name: Commit package.json, VERSION, CHANGELOG.md and create git tag
+        working-directory: host/javascript
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git pull origin --ff-only
+          git add package.json VERSION CHANGELOG.md
+          git commit -m "chore: release host/javascript ${{ steps.release-version.outputs.RELEASE_VERSION }}"
+          git tag "js-v${{ steps.release-version.outputs.RELEASE_VERSION }}"
+          git push origin
+          git push origin --tags
+      # Create GitHub Release
+      - name: Version for Changelog entry
+        id: get-changelog-version
+        env:
+          RELEASE_TAG: ${{ steps.release-level.outputs.RELEASE_TAG }}
+          VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+        run: |
+          if [ "$RELEASE_TAG" = "latest" ]; then
+            echo VERSION="$VERSION"
+          else
+            echo VERSION="" # refers to unreleased section
+          fi
+      - name: Get release version changelog
+        id: get-changelog
+        uses: superfaceai/release-changelog-action@v1
+        with:
+          path-to-changelog: host/javascript/CHANGELOG.md
+          version: ${{ steps.get-changelog-version.outputs.VERSION }}
+          operation: read
+      - name: Update GitHub release documentation
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: "js-v${{ steps.release-version.outputs.RELEASE_VERSION }}"
+          body: ${{ steps.get-changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  host-javascript-publish:
+    name: Publish JavaScript Host
+    needs: [core, host-javascript-prepare]
+    if: ${{ inputs.host == 'js' || inputs.host == 'all' }}
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: https://registry.npmjs.org/
+          node-version: "18"
+          cache: yarn
+          cache-dependency-path: host/javascript/yarn.lock
+      # Build
+      - uses: actions/download-artifact@v3
+        with:
+          name: core-async-wasm
+          path: host/javascript/assets
+      - name: Copy LICENSE
+        run: cp LICENSE host/javascript/LICENSE
+      - name: Build host/javascript
+        working-directory: host/javascript
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+      # Publish
+      - name: Resolve release level
+        id: release-level
+        run: scripts/release-level.sh ${{ inputs.release-level }} ${{ inputs.release-kind }} >>$GITHUB_OUTPUT
+      - name: Resolve release version
+        id: release-version
+        run: scripts/release-version.sh ./host/javascript/VERSION ${{ steps.release-level.outputs.RELEASE_LEVEL }} ${{ steps.release-level.outputs.RELEASE_PREID }} >>$GITHUB_OUTPUT
+      - name: Publish to NPM registry
+        working-directory: host/javascript
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_BOT_PAT }}
+        run: yarn publish --verbose --no-git-tag-version --access public --new-version ${{ steps.release-version.outputs.RELEASE_VERSION }} --tag ${{ steps.release-level.outputs.RELEASE_TAG }}
+
+  host-python-prepare:
+    name: Prepare Python Host
+    needs: [core]
+    if: ${{ inputs.host == 'python' || inputs.host == 'all' }}
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install Python tools
+        run: python -m pip install build toml-cli
+      # Release version
+      - name: Resolve release level
+        id: release-level
+        run: scripts/release-level.sh ${{ inputs.release-level }} ${{ inputs.release-kind }} >>$GITHUB_OUTPUT
+      - name: Resolve release version
+        id: release-version
+        run: scripts/release-version.sh ./host/python/VERSION ${{ steps.release-level.outputs.RELEASE_LEVEL }} ${{ steps.release-level.outputs.RELEASE_PREID }} >>$GITHUB_OUTPUT
+      # Update version
+      - name: Update version in pyproject
+        working-directory: host/python
+        run: toml set --toml-path pyproject.toml project.version  ${{ steps.release-version.outputs.RELEASE_VERSION }}
+      # Build
+      - uses: actions/download-artifact@v3
+        with:
+          name: core-wasm
+          path: host/python/src/one_sdk/assets
+      - name: Build host/python
+        working-directory: host/python
+        run: python -m build
+      # Changelog
+      - name: Update changelog
+        uses: superfaceai/release-changelog-action@v1
+        if: ${{ steps.release-level.outputs.RELEASE_TAG == 'latest' }}
+        with:
+          path-to-changelog: host/python/CHANGELOG.md
+          version: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+          operation: release
+      # Commit release changes
+      - name: Git configuration
+        run: |
+          git config --global user.email "bot@superface.ai"
+          git config --global user.name "GitHub Actions release workflow"
+      - name: Commit pyproject.toml, VERSION, CHANGELOG.md and create git tag
+        working-directory: host/python
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git pull origin --ff-only
+          git add pyproject.toml VERSION CHANGELOG.md
+          git commit -m "chore: release host/python ${{ steps.release-version.outputs.RELEASE_VERSION }}"
+          git tag "python-v${{ steps.release-version.outputs.RELEASE_VERSION }}"
+          git push origin
+          git push origin --tags
+      # Create GitHub Release
+      - name: Version for Changelog entry
+        id: get-changelog-version
+        env:
+          RELEASE_TAG: ${{ steps.release-level.outputs.RELEASE_TAG }}
+          VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+        run: |
+          if [ "$RELEASE_TAG" = "latest" ]; then
+            echo VERSION="$VERSION"
+          else
+            echo VERSION="" # refers to unreleased section
+          fi
+      - name: Get release version changelog
+        id: get-changelog
+        uses: superfaceai/release-changelog-action@v1
+        with:
+          path-to-changelog: host/python/CHANGELOG.md
+          version: ${{ steps.get-changelog-version.outputs.VERSION }}
+          operation: read
+      - name: Update GitHub release documentation
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: "python-v${{ steps.release-version.outputs.RELEASE_VERSION }}"
+          body: ${{ steps.get-changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  host-python-publish:
+    name: Publish Python Host
+    needs: [core, host-python-prepare]
+    if: ${{ inputs.host == 'python' || inputs.host == 'all' }}
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install Python tools
+        run: python -m pip install build toml-cli
+      # Build
+      - uses: actions/download-artifact@v3
+        with:
+          name: core-wasm
+          path: host/python/src/one_sdk/assets
+      - name: Copy LICENSE
+        run: cp LICENSE host/python/LICENSE
+      - name: Build host/python
+        working-directory: host/python
+        run: python -m build
+      # Publish
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: host/python/dist
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+ 
+  trigger_daily:
+    name: Trigger daily build
+    needs: [host-javascript-publish, host-python-publish]
+    if: ${{ !cancelled() && (needs.host-javascript-publish.result == 'success' || needs.host-python-publish.result == 'success') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Daily Test
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GH_BOT_PAT }}
+          repository: superfaceai/superface-daily
+          event-type: on-demand-test

--- a/host/javascript/.gitignore
+++ b/host/javascript/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
-License
+LICENSE
 /assets
 /common
 /cloudflare

--- a/host/python/.gitignore
+++ b/host/python/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 /build
 /dist
 /src/*.egg-info
+LICENSE


### PR DESCRIPTION
Publishing to registry is separated from preparing repository.

This allows us to fix issues on our side and retry publishing. Even rollbacking prepared changes by CI/CD in repository and reruning publish pipeline.

Also creates GitHub release for pre-releases (alpha, beta, rc) and uses unreleased section of chagenlog as description of the release.

When at least one host was released it triggers [superface daily](https://github.com/superfaceai/superface-daily).