### PR TITLE
Mention WASI flag as note only

### DIFF
--- a/host/javascript/README.md
+++ b/host/javascript/README.md
@@ -122,6 +122,12 @@ try {
 Then run the script with:
 
 ```shell
+node index.mjs
+```
+
+_Note: If you are running Node.js before version `18.17.0` you need to enable WASI by providing flag to Node.js:_
+
+```shell
 node --experimental-wasi-unstable-preview1 index.mjs
 ```
 


### PR DESCRIPTION
https://github.com/nodejs/node/pull/47286

WASI preview1 is enabled since node 18.17 and in node 20 be default.

This PR changes it to mention need for flag as note instead having it as mandatory.

I think this makes it less scary for use not familiar with WebAssembly and WASI.