### PR TITLE
Security id can have capitals

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Security values properties are required
 
 ### Changed
 - Security Values are passed as HostValue
+- Security Values are validated using JSON Schema
+- Parameters are validated using JSON Schema

--- a/core/json_schemas/src/schemas/security_values.json
+++ b/core/json_schemas/src/schemas/security_values.json
@@ -2,7 +2,7 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    "^[a-z][_\\-a-z]*$": {
+    "^[a-zA-Z][_\\-a-zA-Z]*$": {
       "type": "object",
       "oneOf": [
         {

--- a/core/json_schemas/src/schemas/security_values.yaml
+++ b/core/json_schemas/src/schemas/security_values.yaml
@@ -2,7 +2,7 @@
 type: object
 additionalProperties: false
 patternProperties:
-  "^[a-z][_\\-a-z]*$":
+  "^[a-zA-Z][_\\-a-zA-Z]*$":
     type: object
     oneOf:
     - type: object


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

Allows capital letters in security ids

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Despite specification and how pattern matching worked with AJV, security ids can contain capital latters.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](https://github.com/superfaceai/one-sdk/blob/main/SECURITY.md) is correct.
- [ ] I have read the [CONTRIBUTING](https://github.com/superfaceai/one-sdk/blob/main/docs/CONTRIBUTING.md) document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All tests passed.
