### PR TITLE
Export function loading Core wasm file

### DIFF
--- a/host/javascript/src/node/wasm.ts
+++ b/host/javascript/src/node/wasm.ts
@@ -1,0 +1,10 @@
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+
+export function corePath(): string {
+  return process.env.CORE_PATH ?? createRequire(import.meta.url).resolve('../assets/core-async.wasm');
+}
+
+export async function loadCoreFile(): Promise<Buffer> {
+  return await readFile(corePath());
+}


### PR DESCRIPTION
This solves an issue in POD, where we tried to load WASM file from within package.

It works for local development, same as using node.js OneClient. So I believe t will work. But perhaps I can publish manually experiement version from this branch, before adding it to main.