### PR TITLE
Fix core path on windows

### DIFF
--- a/host/javascript/src/common/wasm.ts
+++ b/host/javascript/src/common/wasm.ts
@@ -1,3 +1,3 @@
-export function corePath(): string {
-  return process.env.CORE_PATH ?? new URL('../assets/core-async.wasm', import.meta.url).pathname;
+export function corePathURL(): URL {
+  return new URL('../assets/core-async.wasm', import.meta.url);
 }

--- a/host/javascript/src/node/index.ts
+++ b/host/javascript/src/node/index.ts
@@ -17,7 +17,8 @@ import {
   Persistence
 } from '../common/index.js';
 import { fetchErrorToHostError, systemErrorToWasiError } from './error.js';
-import { corePath } from '../common/wasm.js';
+import { corePathURL } from '../common/wasm.js';
+import { fileURLToPath } from 'node:url';
 
 export { PerformError, UnexpectedError, ValidationError } from '../common/index.js';
 export { fetchErrorToHostError, systemErrorToWasiError } from './error.js';
@@ -222,7 +223,7 @@ class InternalClient {
       }
 
       await this.app.loadCore(
-        await fs.readFile(corePath())
+        await fs.readFile(process.env.CORE_PATH ?? fileURLToPath(corePathURL()))
       );
       await this.app.init(new WASI({ env: process.env, version: 'preview1' } as any)); // TODO: node typings do not include version https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/wasi.d.ts#L68-L110
 


### PR DESCRIPTION
Hopefully this will fix an issue where path contained disk label twice:
<img width="1155" alt="image" src="https://github.com/superfaceai/one-sdk/assets/959390/b8ae522d-5359-4e12-ad9c-3184898e999f">
