### PR TITLE
Fix/python host reference cycle

### DIFF
--- a/packages/python_host/pyproject.toml
+++ b/packages/python_host/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "charset-normalizer ~= 3.1.0",
   "idna ~= 3.4",
   "urllib3 ~= 2.0.3",
-  "wasmtime ~= 10.0.0"
+  "wasmtime ~= 13.0.0"
 ]
 
 [project.urls]

--- a/packages/python_host/src/one_sdk/sf_host.py
+++ b/packages/python_host/src/one_sdk/sf_host.py
@@ -40,14 +40,17 @@ def _abi_ok(value: int) -> AbiResult:
 def _abi_err(value: int) -> AbiResult:
 	return _join_abi_result(int(value), 1)
 
-def _get_app(app_ref: ReferenceType["WasiApp"]) -> "WasiApp":
+# We need to use a weak reference because otherwise we cause a reference cycle with wasmtime runtime
+# and leak the whole instance
+# TODO: from 3.9 we can do ReferenceType["WasiApp"]
+def _get_app(app_ref: ReferenceType) -> "WasiApp":
 	app = app_ref()
 	if app is None:
 		raise RuntimeError("WasiApp already destroyed")
 	
 	return app
 
-def link(linker: Linker, app_ref: ReferenceType["WasiApp"]):
+def link(linker: Linker, app_ref: ReferenceType):
 	message_store: HandleMap[bytes] = HandleMap()
 
 	def __export_message_exchange(msg_ptr: Ptr, msg_len: Size, out_ptr: Ptr, out_len: Size, ret_handle: Ptr) -> Size:


### PR DESCRIPTION
## Description
Fixes Python memory leak caused by creating a reference cycle between wasm Engine and wasm imports/callbacks

## Motivation and Context
Discovered during initial performance testing (see #108), this is leaking memory (it's only freed on python process shutdown, which is incorrect)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
