### PR TITLE
feat: allow disabling autosending metrics

### DIFF
--- a/examples/run.sh
+++ b/examples/run.sh
@@ -4,7 +4,7 @@ base=$(dirname "$0")
 base=$(realpath "$base")
 cd "$base"
 
-MAKE_FLAGS=${2:-MODE=debug}
+MAKE_FLAGS=${2}
 
 case $1 in
 	node)

--- a/packages/python_host/src/one_sdk/client.py
+++ b/packages/python_host/src/one_sdk/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Union
 
 import os
 import os.path
@@ -16,7 +16,7 @@ class InternalClient:
 		self,
 		assets_path: str,
 		token: Optional[str],
-		superface_api_url: str
+		superface_api_url: Union[None, str, bool]
 	):
 		self._assets_path = assets_path
 		self._core_path = CORE_PATH
@@ -139,7 +139,7 @@ class OneClient:
 		self,
 		assets_path: str = "superface",
 		token: Optional[str] = None,
-		superface_api_url: str = "https://superface.ai"
+		superface_api_url: Union[None, str, bool] = None
 	):
 		self._internal = InternalClient(
 			assets_path = assets_path,

--- a/packages/python_host/src/one_sdk/platform.py
+++ b/packages/python_host/src/one_sdk/platform.py
@@ -1,4 +1,4 @@
-from typing import BinaryIO, List, Mapping, Optional, cast
+from typing import BinaryIO, List, Mapping, Optional, Union, cast
 
 from datetime import datetime
 from collections import defaultdict
@@ -178,10 +178,12 @@ class PythonNetwork:
 		return DeferredHttpResponse(response, exception)
 
 class PythonPersistence:
-	def __init__(self, token: Optional[str] = None, superface_api_url: Optional[str] = None, user_agent: Optional[str] = None):
+	def __init__(self, token: Optional[str] = None, superface_api_url: Union[None, str, bool] = None, user_agent: Optional[str] = None):
 		self._token = token
 		self._user_agent = user_agent
-		if superface_api_url is not None:
+		if superface_api_url is False:
+			self._insights_url = False
+		elif superface_api_url is not None:
 			self._insights_url = f"{superface_api_url}/insights/sdk_event"
 		else:
 			self._insights_url = "https://superface.ai/insights/sdk_event"
@@ -189,6 +191,9 @@ class PythonPersistence:
 		self._network = PythonNetwork()
 
 	def persist_metrics(self, events: List[str]):
+		if self._insights_url is False:
+			return
+
 		headers = {
 			"content-type": ["application/json"]
 		}


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Allows disabling the automatic sending of metrics and on exit hooks. Metrics are still generated and need to be consumed periodically - this might need to be changed later.

## Motivation and Context
During initial performance testing (see #108) this was required but this usecase might be important, and it is already implemented for cloudflare host.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
