### PR TITLE
feat: improve map-std types

### DIFF
--- a/core_js/map-std/src/internal/bytes.ts
+++ b/core_js/map-std/src/internal/bytes.ts
@@ -18,6 +18,14 @@ export class Bytes {
     return new Bytes(new Uint8Array(array), array.length);
   }
 
+  static isBytes(value: unknown): value is Bytes {
+    if (value === undefined || value === null) {
+      return false;
+    }
+
+    return value instanceof Bytes;
+  }
+
   toArray(): number[] {
     return Array.from(this.data);
   }

--- a/core_js/map-std/src/internal/node_compat.ts
+++ b/core_js/map-std/src/internal/node_compat.ts
@@ -8,6 +8,10 @@ export class Buffer {
       return new Buffer(Bytes.encode(value, encoding));
     }
 
+    if (Bytes.isBytes(value)) {
+      return new Buffer(value);
+    }
+
     if (Buffer.isBuffer(value)) {
       return value;
     }
@@ -24,11 +28,7 @@ export class Buffer {
       return false;
     }
 
-    if (value instanceof Buffer) {
-      return true;
-    }
-
-    return false;
+    return value instanceof Buffer;
   }
 
   #inner: Bytes;

--- a/core_js/map-std/src/map_std.ts
+++ b/core_js/map-std/src/map_std.ts
@@ -2,12 +2,22 @@ import { Buffer as NodeBuffer } from './internal/node_compat';
 import * as unstable from './unstable';
 
 declare global {
-  type UsecaseFn = (context: {input: unstable.AnyValue, parameters: Record<string, unstable.AnyValue>, services: Record<string, string> }) => unstable.AnyValue;
+  // types
+  type AnyValue = unstable.AnyValue;
+  type UsecaseContext<I extends AnyValue = AnyValue> = {
+    input: I,
+    parameters: Record<string, string>,
+    services: Record<string, string>
+  };
+  type UsecaseFn<I extends AnyValue = AnyValue, R extends AnyValue = AnyValue> = (context: UsecaseContext<I>) => R;
+  type MapError<R extends AnyValue = AnyValue> = unstable.MapError<R>;
+  // globals
   var std: {
     unstable: typeof unstable
   };
-  function _start(usecaseName: string): void;
   var Buffer: typeof NodeBuffer;
+  // functions
+  function _start(usecaseName: string): void;
 };
 globalThis.std = { unstable };
 globalThis.Buffer = NodeBuffer;
@@ -15,6 +25,7 @@ globalThis.Buffer = NodeBuffer;
 globalThis._start = function _start(usecaseName: string): void {
   const context = globalThis.std.unstable.takeContext() as Record<string, unstable.AnyValue>;
 
+  // search for the usecase as a freestanding function
   // TODO: this is best-effort - these are functions currently visible in the global scope
   const globalSymbols = new Set(['_start', 'Object', 'Function', 'Error', 'EvalError', 'RangeError', 'ReferenceError', 'SyntaxError', 'TypeError', 'URIError', 'InternalError', 'AggregateError', 'Array', 'parseInt', 'parseFloat', 'isNaN', 'isFinite', 'decodeURI', 'decodeURIComponent', 'encodeURI', 'encodeURIComponent', 'escape', 'unescape', '__date_clock', 'Number', 'Boolean', 'String', 'Symbol', 'eval', 'Date', 'RegExp', 'Proxy', 'Map', 'Set', 'WeakMap', 'WeakSet', 'ArrayBuffer', 'SharedArrayBuffer', 'Uint8ClampedArray', 'Int8Array', 'Uint8Array', 'Int16Array', 'Uint16Array', 'Int32Array', 'Uint32Array', 'BigInt64Array', 'BigUint64Array', 'Float32Array', 'Float64Array', 'DataView', 'Promise', 'BigInt', 'Buffer']);
   const usecases = Object.getOwnPropertyNames(globalThis).filter(
@@ -23,12 +34,13 @@ globalThis._start = function _start(usecaseName: string): void {
   if (!usecases.includes(usecaseName)) {
     throw new Error(`Usecase ${usecaseName} not defined, usecases: ${usecases.join(', ')}`);
   }
-  
+
   const usecase: UsecaseFn = (globalThis as any)[usecaseName];
+
   try {
     const result = usecase({
       input: context.input,
-      parameters: context.parameters as Record<string, unstable.AnyValue>,
+      parameters: context.parameters as Record<string, string>,
       services: context.services as Record<string, string>
     });
     globalThis.std.unstable.setOutputSuccess(result);

--- a/core_js/map-std/src/unstable.ts
+++ b/core_js/map-std/src/unstable.ts
@@ -10,7 +10,7 @@ export type FetchOptions = {
   method?: string,
   headers?: MultiMap,
   query?: MultiMap,
-  body?: string | number[] | Buffer,
+  body?: AnyValue,
   security?: string,
 };
 
@@ -68,18 +68,18 @@ export class HttpResponse {
     return bytes.decode();
   }
 
-  public bodyJson(): unknown {
+  public bodyJson(): AnyValue {
     const text = this.bodyText();
-    if (text === undefined || text === '') {
-      return undefined;
+    if (text == null || text === '') {
+      return null;
     }
 
     return JSON.parse(text);
   }
 
-  public bodyAuto(): unknown {
+  public bodyAuto(): AnyValue | Buffer {
     if (this.status === 204) {
-      return undefined;
+      return null;
     }
 
     if (this.headers['content-type']?.some(ct => ct.indexOf(CONTENT_TYPE.JSON) >= 0) ?? false) {
@@ -87,15 +87,15 @@ export class HttpResponse {
     }
 
     if (this.headers['content-type']?.some(ct => CONTENT_TYPE.RE_BINARY.test(ct)) ?? false) {
-      return this.bodyBytes();
+      return Buffer.from(this.bodyBytes());
     }
 
     return this.bodyText();
   }
 }
 
-export class MapError {
-  constructor(public readonly errorResult: AnyValue) { }
+export class MapError<R extends AnyValue = AnyValue> {
+  constructor(public readonly errorResult: R) { }
 }
 
 // env

--- a/examples/comlinks/src/communication.send-email.mailchimp.map.js
+++ b/examples/comlinks/src/communication.send-email.mailchimp.map.js
@@ -1,13 +1,14 @@
 /// <reference types="@superface/map-std" />
+// @ts-check
 
-/** @type {UsecaseFn} */
+/** @type {UsecaseFn<{ from: AnyValue, to: AnyValue, subject: AnyValue, text?: AnyValue, html?: AnyValue, attachments?: [{ content: AnyValue, type: AnyValue, filename?: AnyValue }] }, { messageId: AnyValue }>} */
 function SendEmail({ input, services }) {
   const url = `${services.mandrill}/api/1.0/messages/send`;
   const options = {
     method: 'POST',
     headers: {
-      'content-type': 'application/json',
-      'accept': 'application/json'
+      'content-type': ['application/json'],
+      'accept': ['application/json']
     },
     body: {
       key: 'key-will-go-here',
@@ -18,19 +19,20 @@ function SendEmail({ input, services }) {
           type: 'to'
         }],
         subject: input.subject,
-        text: input.text ?? undefined,
-        html: input.html ?? undefined,
+        text: input.text ?? null,
+        html: input.html ?? null,
         attachments: input.attachments?.map(attachment => ({
           content: attachment.content,
-          name: attachment.filename,
+          name: attachment.filename ?? null,
           type: attachment.type,
-        })) ?? undefined
+        })) ?? null
       }
     },
     security: 'api_key'
   };
 
   const response = std.unstable.fetch(url, options).response();
+  /** @type {any} */
   const body = response.bodyAuto() ?? {};
 
   if (response.status === 500) {

--- a/examples/comlinks/src/communication.send-sms.twilio.map.js
+++ b/examples/comlinks/src/communication.send-sms.twilio.map.js
@@ -1,24 +1,25 @@
 /// <reference types="@superface/map-std" />
+// @ts-check
 
-/** @type {UsecaseFn} */
+/** @type {UsecaseFn<{ to?: AnyValue, from?: AnyValue, text?: AnyValue }, { messageId: AnyValue }>} */
 function SendMessage({ input, parameters, services }) {
   const url = `${services.default}/2010-04-01/Accounts/${parameters.TWILIO_ACCOUNT_SID}/Messages.json`;
   const options = {
     method: 'POST',
     headers: {
-      'Accept': 'application/json',
-      'Content-type': 'application/x-www-form-urlencoded'
+      'Accept': ['application/json'],
+      'Content-type': ['application/x-www-form-urlencoded']
     },
     body: {
-      To: input.to,
-      From: parameters.from,
-      Body: input.text
+      To: input.to ?? null,
+      From: parameters.from ?? null,
+      Body: input.text ?? null
     },
     security: 'basic'
   };
 
   const response = std.unstable.fetch(url, options).response();
-  const body = response.bodyAuto() ?? {};
+  const body = /** @type {Record<string, AnyValue>} */ (response.bodyAuto() ?? {});
   if (response.status !== 201) {
     throw new std.unstable.MapError({
       title: 'Unexpected response',

--- a/examples/comlinks/src/communication.send-sms.tyntec.map.js
+++ b/examples/comlinks/src/communication.send-sms.tyntec.map.js
@@ -1,24 +1,25 @@
 /// <reference types="@superface/map-std" />
+// @ts-check
 
-/** @type {UsecaseFn} */
+/** @type {UsecaseFn<{ to?: AnyValue, from?: AnyValue, text?: AnyValue }, { messageId: AnyValue }>} */
 function SendMessage({ input, parameters, services }) {
   const url = `${services.default}/messaging/v1/sms`;
   const options = {
     method: 'POST',
     headers: {
-      'Accept': 'application/json',
-      'Content-type': 'application/json'
+      'Accept': ['application/json'],
+      'Content-type': ['application/json']
     },
     body: {
-      to: input.to,
-      from: parameters.from,
-      message: input.text
+      to: input.to ?? null,
+      from: parameters.from ?? null,
+      message: input.text ?? null
     },
     security: 'apikey'
   };
 
   const response = std.unstable.fetch(url, options).response();
-  const body = response.bodyAuto() ?? {};
+  const body = /** @type {Record<string, AnyValue>} */ (response.bodyAuto() ?? {});
   if (response.status !== 202) {
     throw new std.unstable.MapError({
       title: `Unexpected response status ${response.status}`,

--- a/examples/comlinks/src/wasm-sdk.example.localhost.map.js
+++ b/examples/comlinks/src/wasm-sdk.example.localhost.map.js
@@ -1,11 +1,18 @@
+/// <reference types="@superface/map-std" />
+// @ts-check
+
 const manifest = {
   profile: 'wasm-sdk/example@0.1',
   provider: 'localhost'
 };
 
+/** @type {UsecaseFn<{ id: AnyValue }, { url: AnyValue, method: AnyValue, query: AnyValue, headers: AnyValue }>} */
 function Example({ input, parameters, services }) {
+  // @ts-ignore
   __ffi.unstable.printDebug('Input:', input);
+  // @ts-ignore
   __ffi.unstable.printDebug('Parameters:', parameters);
+  // @ts-ignore
   __ffi.unstable.printDebug('Services:', services);
 
   const url = `${services.default}/api/${input.id}`;
@@ -13,8 +20,8 @@ function Example({ input, parameters, services }) {
   const options = {
     method: 'GET',
     headers: {
-      'Accept': 'application/json',
-      'x-custom-header': parameters.PARAM
+      'Accept': ['application/json'],
+      'x-custom-header': [parameters.PARAM]
     },
     security: 'basic_auth',
     query: {
@@ -27,7 +34,7 @@ function Example({ input, parameters, services }) {
   let body
   try {
     response = std.unstable.fetch(url, options).response();
-    body = response.bodyAuto() ?? {};
+    body = /** @type {Record<string, AnyValue>} */ (response.bodyAuto() ?? {});
   } catch (err) {
     throw new std.unstable.MapError({
       title: err.name,


### PR DESCRIPTION
* made MapError generic over the value it stores
* made UsecaseContext and UsecaseFn generic over input, result and error
* export MapError and AnyValue types into the global namespace of the map-std types (this is sort of like stabilising them, but they are just types and we don't currently distribute those)
* correctly type Response.bodyJson and Response.bodyAuto (add Buffer into the possible return types)
* improve Buffer.from to also accept Bytes
* update example maps with more correct typings
* fix provider parameters type to only string values
* fix FetchOptions.body type to AnyValue

Some improvements I realized can be useful as I was experimenting with TypeScript profiles