### PR TITLE
chore: fix rust 1.74 warning

### DIFF
--- a/core/core/src/sf_core.rs
+++ b/core/core/src/sf_core.rs
@@ -55,10 +55,10 @@ pub struct OneClientCore {
     mapstd_config: MapStdImplConfig,
 }
 impl OneClientCore {
-    const MAP_STDLIB_JS: &str = include_str!("../assets/js/map_std.js");
-    const SECURITY_VALUES_JSON_SCHEMA: &str =
+    const MAP_STDLIB_JS: &'static str = include_str!("../assets/js/map_std.js");
+    const SECURITY_VALUES_JSON_SCHEMA: &'static str =
         include_str!("../assets/schemas/security_values.json");
-    const PARAMETERS_VALUES_JSON_SCHEMA: &str =
+    const PARAMETERS_VALUES_JSON_SCHEMA: &'static str =
         include_str!("../assets/schemas/parameters_values.json");
 
     // TODO: Use thiserror and define specific errors

--- a/core/core/src/sf_core/cache.rs
+++ b/core/core/src/sf_core/cache.rs
@@ -111,10 +111,10 @@ pub struct DocumentCache<E> {
     user_agent: Option<String>,
 }
 impl<E> DocumentCache<E> {
-    const FILE_URL_PREFIX: &str = "file://";
-    const HTTP_URL_PREFIX: &str = "http://";
-    const HTTPS_URL_PREFIX: &str = "https://";
-    const BASE64_URL_PREFIX: &str = "data:;base64,";
+    const FILE_URL_PREFIX: &'static str = "file://";
+    const HTTP_URL_PREFIX: &'static str = "http://";
+    const HTTPS_URL_PREFIX: &'static str = "https://";
+    const BASE64_URL_PREFIX: &'static str = "data:;base64,";
 
     pub fn new(cache_duration: Duration, registry_url: Url, user_agent: Option<String>) -> Self {
         Self {

--- a/core/core/src/sf_core/profile_validator.rs
+++ b/core/core/src/sf_core/profile_validator.rs
@@ -32,7 +32,7 @@ pub struct ProfileValidator {
     usecase: String,
 }
 impl ProfileValidator {
-    const PROFILE_VALIDATOR_JS: &str = include_str!("../../assets/js/profile_validator.js");
+    const PROFILE_VALIDATOR_JS: &'static str = include_str!("../../assets/js/profile_validator.js");
 
     pub fn new(profile: String, usecase: String) -> Result<Self, ProfileValidatorError> {
         let mut interpreter = JsInterpreter::new(MapStdImpl::new(MapStdImplConfig {


### PR DESCRIPTION
* associated consts need an explicit lifetime

Just a fix for warnings/deprecations that started appearing with rust 1.74