### PR TITLE
Feat/backport bundling improvements

### DIFF
--- a/packages/javascript_common/src/error.ts
+++ b/packages/javascript_common/src/error.ts
@@ -1,4 +1,4 @@
-export * from './lib/error';
+export * from './lib/error.js';
 
 export abstract class BaseError extends Error {
   constructor(name: string, message: string) {

--- a/packages/javascript_common/src/index.ts
+++ b/packages/javascript_common/src/index.ts
@@ -3,4 +3,3 @@ export * from './error.js';
 export type { FileSystem, Network, Persistence, TextCoder, Timers, WasiContext } from './interfaces.js';
 export type { SecurityValuesMap } from './security.js';
 export { HandleMap, AsyncMutex } from './lib/index.js';
-export { corePathURL } from './wasm.js';

--- a/packages/javascript_common/src/interfaces.ts
+++ b/packages/javascript_common/src/interfaces.ts
@@ -1,4 +1,4 @@
-export * from './lib/interfaces';
+export * from './lib/interfaces.js';
 export interface FileSystem {
   /** Return true if the file exists (can be `stat`ed). */
   exists(path: string): Promise<boolean>;

--- a/packages/javascript_common/src/wasm.ts
+++ b/packages/javascript_common/src/wasm.ts
@@ -1,5 +1,0 @@
-export function corePathURL(): URL {
-  // relative to where common is symlinked
-  // up two times gets us from dist/common into the outer package
-  return new URL('../../assets/core-async.wasm', import.meta.url);
-}

--- a/packages/nodejs_host/src/index.ts
+++ b/packages/nodejs_host/src/index.ts
@@ -2,7 +2,6 @@ import fs, { FileHandle } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { resolve as resolvePath } from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
 import { WASI } from 'node:wasi';
 
 import { AsyncMutex } from './common/lib/index.js';
@@ -17,12 +16,14 @@ import {
   Timers,
   UnexpectedError,
   WasiErrno,
-  WasiError,
-  corePathURL
+  WasiError
 } from './common/index.js';
 import { fetchErrorToHostError, systemErrorToWasiError } from './error.js';
 
 const pkg = createRequire(import.meta.url)('../package.json');
+function corePathURL(): URL {
+  return new URL('../assets/core-async.wasm', import.meta.url);
+}
 
 export { PerformError, UnexpectedError, ValidationError } from './common/index.js';
 export { fetchErrorToHostError, systemErrorToWasiError } from './error.js';
@@ -264,7 +265,7 @@ class InternalClient {
       }
 
       await this.app.loadCore(
-        await fs.readFile(process.env.CORE_PATH ?? fileURLToPath(corePathURL()))
+        await fs.readFile(process.env.CORE_PATH ?? corePathURL().pathname)
       );
       await this.app.init(new WASI({
         env: {


### PR DESCRIPTION
* pod and now also nodejs_comlink use a slightly different way to import the WASM asset, so backport that in here as well as it seems more portable
* ensure all imports and reexports in javascript_common have a file extension so that they corrently work with bundlers
* cleanup forgotten code


Draft because it's based on #124 (diff https://github.com/superfaceai/one-sdk/compare/feat/typescript_profile_parser...feat/backport_bundling_improvements)