### PR TITLE
Feat/prepare services map error

### DIFF
--- a/.github/workflows/release-comlink.yml
+++ b/.github/workflows/release-comlink.yml
@@ -186,7 +186,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   nodejs-comlink-publish:
-    name: Publich Node.js Comlink
+    name: Publish Node.js Comlink
     needs: [comlink, nodejs-comlink-prepare]
     if: ${{ !cancelled() && needs.nodejs-comlink-prepare.result == 'success' }}
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ ${WASI_SDK_FOLDER}:
 	wget -qO - ${WASI_SDK_URL} | tar xzvf - -C core
 
 test_core: ${WASI_SDK_FOLDER} ${CORE_JS_ASSETS_MAP_STD} ${CORE_JS_ASSETS_PROFILE_VALIDATOR} ${CORE_SCHEMA_ASSETS_SECURITY_VALUES} ${CORE_SCHEMA_ASSETS_PARAMETERS_VALUES}
-	cd core && cargo test -- -- --nocapture
+	cd core && cargo test -- --nocapture
 
 build_core: ${CORE_WASM} ${TEST_CORE_WASM} ${CORE_ASYNCIFY_WASM} ${TEST_CORE_ASYNCIFY_WASM}
 build_core_json_schemas:

--- a/core/comlink/src/comlink_parser/syntax/mod.rs
+++ b/core/comlink/src/comlink_parser/syntax/mod.rs
@@ -1,6 +1,6 @@
 mod tree;
 
-pub use tree::{nodes::*, tokens::*, AstNode, CstNode, CstToken, Parser, ParserError};
+pub use tree::{nodes::*, AstNode, CstNode, CstToken, ParserError};
 
 /// All syntax token kinds that this parser can produce.
 ///

--- a/core/comlink/src/comlink_parser/syntax/tree.rs
+++ b/core/comlink/src/comlink_parser/syntax/tree.rs
@@ -13,7 +13,7 @@ pub mod serde;
 pub mod tokens;
 
 pub use self::{
-    location::{Location, LocationSpan},
+    location::LocationSpan,
     parser::{Parser, ParserError},
 };
 use location::RawLocation;

--- a/core/core/src/sf_core.rs
+++ b/core/core/src/sf_core.rs
@@ -274,7 +274,9 @@ impl OneClientCore {
             provider_json,
             &perform_input.map_security
         ));
-        let map_services = prepare_services_map(provider_json, &map_parameters);
+        let map_services = try_metrics!(
+            prepare_services_map(provider_json, &map_parameters)
+        );
 
         let ProfileCacheEntry {
             profile: _,

--- a/core/core_to_map_std/src/unstable/services.rs
+++ b/core/core_to_map_std/src/unstable/services.rs
@@ -1,37 +1,91 @@
-use regex::Regex;
-use sf_std::unstable::provider::ProviderJson;
+use std::fmt::Write;
+
+use regex::{Regex, Captures};
+use sf_std::unstable::{provider::ProviderJson, exception::{PerformException, PerformExceptionErrorCode}};
 
 use super::{MapValue, MapValueObject};
 
-pub fn prepare_services_map(provider_json: &ProviderJson, parameters: &MapValueObject) -> MapValue {
-    let mut services_map = MapValueObject::new();
-
-    for service in &provider_json.services {
-        let service_url = replace_parameters(service.base_url.clone(), parameters);
-        services_map.insert(service.id.to_string(), MapValue::String(service_url));
+#[derive(Debug, thiserror::Error)]
+pub enum PrepareServicesMapError {
+    #[error("Service is misconfigured:\n{}", ServiceMisconfiguredError::format_errors(.0.as_slice()))]
+    ServicesMisconfigured(Vec<ServiceMisconfiguredError>)
+}
+impl From<PrepareServicesMapError> for PerformException {
+    fn from(value: PrepareServicesMapError) -> Self {
+        PerformException {
+            error_code: PerformExceptionErrorCode::PrepareServicesMapError,
+            message: value.to_string(),
+        }
     }
-
-    MapValue::Object(services_map)
 }
 
-fn replace_parameters(url: String, parameters: &MapValueObject) -> String {
-    let re = Regex::new(r"\{\s*([^}\s]*)\s*\}").unwrap();
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct ServiceMisconfiguredError {
+    pub id: String,
+    pub expected: String,
+}
+impl ServiceMisconfiguredError {
+    pub fn format_errors(errors: &[Self]) -> String {
+        let mut res = String::new();
 
-    let mut result_url = url.clone();
+        for err in errors {
+            writeln!(
+                &mut res,
+                "Service {} is misconfigured. Expected {}",
+                err.id, err.expected
+            )
+            .unwrap();
+        }
 
-    for cap in re.captures_iter(url.as_str()) {
-        let param_name = &cap[1];
-        let param_value = parameters.get(param_name).unwrap();
+        res
+    }
+}
 
-        match param_value {
-            MapValue::String(val) => {
-                result_url = result_url.as_str().replace(&cap[0], val);
-            }
-            _ => panic!("Invalid parameter value"),
+pub fn prepare_services_map(provider_json: &ProviderJson, parameters: &MapValueObject) -> Result<MapValue, PrepareServicesMapError> {
+    let mut services_map = MapValueObject::new();
+    let mut errors = Vec::new();
+
+    for service in &provider_json.services {
+        match replace_parameters(&service.base_url, parameters) {
+            Ok(service_url) => { services_map.insert(service.id.to_string(), MapValue::String(service_url)); }
+            Err(errs) => errors.extend(
+                errs.into_iter().map(|expected| ServiceMisconfiguredError {
+                    id: service.id.to_owned(),
+                    expected
+                })
+            )
         }
     }
 
-    result_url
+    if !errors.is_empty() {
+        Err(PrepareServicesMapError::ServicesMisconfigured(errors))
+    } else {
+        Ok(MapValue::Object(services_map))
+    }
+}
+
+fn replace_parameters(url: &str, parameters: &MapValueObject) -> Result<String, Vec<String>> {
+    let re = Regex::new(r"\{\s*([^}\s]*)\s*\}").unwrap();
+
+    let mut errors = Vec::new();
+    let result_url = re.replace_all(url, |cap: &Captures| {
+        let param_name = &cap[1];
+
+        match parameters.get(param_name) {
+            Some(MapValue::String(val)) => val,
+            _ => {
+                errors.push(format!("String parameter {}", param_name));
+                ""
+            }
+        }
+    });
+
+    if !errors.is_empty() {
+        Err(errors)
+    } else {
+        Ok(result_url.into_owned())
+    }
 }
 
 #[cfg(test)]
@@ -41,18 +95,35 @@ mod test {
     #[test]
     fn test_params_replacing() {
         let result_url = replace_parameters(
-            "http://{ONE}.localhost/{ TWO}/{THREE }/{ FOUR }".to_string(),
+            "http://{ONE}.localhost/{ TWO}/{THREE }/{ FOUR }",
             &MapValueObject::from([
                 ("ONE".to_string(), MapValue::String("first".to_string())),
                 ("TWO".to_string(), MapValue::String("second".to_string())),
                 ("THREE".to_string(), MapValue::String("third".to_string())),
                 ("FOUR".to_string(), MapValue::String("fourth".to_string())),
             ]),
-        );
+        ).unwrap();
 
         assert_eq!(
             result_url,
             "http://first.localhost/second/third/fourth".to_string()
         );
+    }
+
+    #[test]
+    fn test_params_replacing_wrong_params() {
+        let err = replace_parameters(
+            "http://{ONE}.localhost/{ TWO}/{THREE }/{ FOUR }",
+            &MapValueObject::from([
+                ("ONE".to_string(), MapValue::String("first".to_string())),
+                ("TWO".to_string(), MapValue::String("second".to_string())),
+                ("THREE".to_string(), MapValue::None),
+            ]),
+        ).unwrap_err();
+
+        assert_eq!(err, vec![
+            "String parameter THREE".to_string(),
+            "String parameter FOUR".to_string()
+        ]);
     }
 }

--- a/core/host_to_core_std/src/unstable/exception.rs
+++ b/core/host_to_core_std/src/unstable/exception.rs
@@ -7,6 +7,7 @@ pub enum PerformExceptionErrorCode {
     JsInterpreterError,
     ParametersFormatError,
     PrepareSecurityMapError,
+    PrepareServicesMapError,
     ReplacementStdlibError,
     TakeInputError,
 }
@@ -19,6 +20,9 @@ impl std::fmt::Display for PerformExceptionErrorCode {
             PerformExceptionErrorCode::ParametersFormatError => write!(f, "ParametersFormatError"),
             PerformExceptionErrorCode::PrepareSecurityMapError => {
                 write!(f, "PrepareSecurityMapError")
+            }
+            PerformExceptionErrorCode::PrepareServicesMapError => {
+                write!(f, "PrepareServicesMapError")
             }
             PerformExceptionErrorCode::ReplacementStdlibError => {
                 write!(f, "ReplacementStdlibError")

--- a/packages/nodejs_comlink/README.md
+++ b/packages/nodejs_comlink/README.md
@@ -5,4 +5,4 @@
 
 # Superface Comlink tools
 
-Contains Comlink tooling (profile parse, JSON schema generation and validation).
+Contains Comlink tooling (profile parser, JSON schema generation and validation).


### PR DESCRIPTION
Emit error when `prepare_services_map` encounters a parameter that does not exist, have a value or is not String. This is very similar to how security values are resolved.

Plus some small changes fixing typos