### PR TITLE
feat: don't emit AnyValue in UseCase schema when unused

### DIFF
--- a/core/comlink/tests/fixtures/typescript_profile/p1.profile.json
+++ b/core/comlink/tests/fixtures/typescript_profile/p1.profile.json
@@ -15,36 +15,6 @@
         "title": "The usecase title"
       },
       "error": {
-        "$defs": {
-          "AnyValue": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "items": {
-                  "$ref": "#/$defs/AnyValue"
-                },
-                "type": "array"
-              },
-              {
-                "additionalProperties": {
-                  "$ref": "#/$defs/AnyValue"
-                },
-                "type": "object"
-              }
-            ]
-          }
-        },
         "oneOf": [
           {
             "additionalProperties": false,
@@ -96,36 +66,6 @@
         }
       ],
       "input": {
-        "$defs": {
-          "AnyValue": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "items": {
-                  "$ref": "#/$defs/AnyValue"
-                },
-                "type": "array"
-              },
-              {
-                "additionalProperties": {
-                  "$ref": "#/$defs/AnyValue"
-                },
-                "type": "object"
-              }
-            ]
-          }
-        },
         "additionalProperties": false,
         "properties": {
           "id": {

--- a/core/comlink/tests/fixtures/typescript_profile/p1.profile.ts
+++ b/core/comlink/tests/fixtures/typescript_profile/p1.profile.ts
@@ -1,4 +1,4 @@
-/// <reference types="@superface/map-std" />
+/// <reference types="@superfaceai/map-std" />
 
 /**
  * The usecase title

--- a/examples/comlinks/package.json
+++ b/examples/comlinks/package.json
@@ -2,6 +2,6 @@
   "name": "comlinks",
   "private": true,
   "devDependencies": {
-    "@superface/map-std": "link:../../packages/map_std"
+    "@superfaceai/map-std": "link:../../packages/map_std"
   }
 }

--- a/examples/comlinks/src/wasm-sdk.example.profile.ts
+++ b/examples/comlinks/src/wasm-sdk.example.profile.ts
@@ -1,4 +1,4 @@
-/// <reference types="@superface/map-std" />
+/// <reference types="@superfaceai/map-std" />
 type Example = UseCase<{
   safety: 'safe'
   input: { id: AnyValue }

--- a/packages/nodejs_comlink/src/index.test.ts
+++ b/packages/nodejs_comlink/src/index.test.ts
@@ -51,36 +51,6 @@ const UseCaseExamples: UseCaseName['examples'] = [
           "title": null
         },
         "error": {
-          "$defs": {
-            "AnyValue": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "boolean"
-                },
-                {
-                  "items": {
-                    "$ref": "#/$defs/AnyValue"
-                  },
-                  "type": "array"
-                },
-                {
-                  "additionalProperties": {
-                    "$ref": "#/$defs/AnyValue"
-                  },
-                  "type": "object"
-                }
-              ]
-            }
-          },
           "oneOf": [
             {
               "additionalProperties": false,
@@ -132,36 +102,6 @@ const UseCaseExamples: UseCaseName['examples'] = [
           }
         ],
         "input": {
-          "$defs": {
-            "AnyValue": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "boolean"
-                },
-                {
-                  "items": {
-                    "$ref": "#/$defs/AnyValue"
-                  },
-                  "type": "array"
-                },
-                {
-                  "additionalProperties": {
-                    "$ref": "#/$defs/AnyValue"
-                  },
-                  "type": "object"
-                }
-              ]
-            }
-          },
           "additionalProperties": false,
           "properties": {
             "id": {


### PR DESCRIPTION
* Profile parser was emitting AnyValue into all input and output schemas, but it only has to appear in schemas which make use of it
