### PR TITLE
Feat/multiple securities

### DIFF
--- a/core/core/src/sf_core/map_std_impl/mod.rs
+++ b/core/core/src/sf_core/map_std_impl/mod.rs
@@ -90,9 +90,11 @@ impl MapStdUnstable for MapStdImpl {
         }
     }
 
-    fn http_call(&mut self, mut params: MapHttpRequest, security: MapHttpRequestSecurity) -> Result<Handle, MapHttpCallError> {
+    fn http_call(&mut self, mut params: MapHttpRequest, security: Option<MapHttpRequestSecurity>) -> Result<Handle, MapHttpCallError> {
         let security_map = self.security.as_ref().unwrap();
-        resolve_security(security_map, &mut params, &security)?;
+        if let Some(ref security) = security {
+            resolve_security(security_map, &mut params, security)?;
+        }
 
         // IDEA: add profile, provider info as well?
         params

--- a/core/core/src/sf_core/map_std_impl/mod.rs
+++ b/core/core/src/sf_core/map_std_impl/mod.rs
@@ -5,7 +5,7 @@ use map_std::{
     unstable::{
         security::{resolve_security, SecurityMap},
         HttpCallError as MapHttpCallError, HttpCallHeadError as MapHttpCallHeadError,
-        HttpRequest as MapHttpRequest, HttpResponse as MapHttpResponse, MapStdUnstable, MapValue,
+        HttpRequest as MapHttpRequest, HttpRequestSecurity as MapHttpRequestSecurity, HttpResponse as MapHttpResponse, MapStdUnstable, MapValue,
         SetOutputError, TakeContextError,
     },
     MapStdFull,
@@ -90,9 +90,9 @@ impl MapStdUnstable for MapStdImpl {
         }
     }
 
-    fn http_call(&mut self, mut params: MapHttpRequest) -> Result<Handle, MapHttpCallError> {
+    fn http_call(&mut self, mut params: MapHttpRequest, security: MapHttpRequestSecurity) -> Result<Handle, MapHttpCallError> {
         let security_map = self.security.as_ref().unwrap();
-        resolve_security(security_map, &mut params)?;
+        resolve_security(security_map, &mut params, &security)?;
 
         // IDEA: add profile, provider info as well?
         params

--- a/core/interpreter_js/src/lib.rs
+++ b/core/interpreter_js/src/lib.rs
@@ -139,7 +139,7 @@ mod test {
         fn http_call(
             &mut self,
             _params: map_std::unstable::HttpRequest,
-            _security: map_std::unstable::HttpRequestSecurity
+            _security: Option<map_std::unstable::HttpRequestSecurity>
         ) -> Result<sf_std::abi::Handle, map_std::unstable::HttpCallError> {
             Ok(1)
         }

--- a/core/interpreter_js/src/lib.rs
+++ b/core/interpreter_js/src/lib.rs
@@ -139,6 +139,7 @@ mod test {
         fn http_call(
             &mut self,
             _params: map_std::unstable::HttpRequest,
+            _security: map_std::unstable::HttpRequestSecurity
         ) -> Result<sf_std::abi::Handle, map_std::unstable::HttpCallError> {
             Ok(1)
         }

--- a/core_js/map-std/src/unstable.ts
+++ b/core_js/map-std/src/unstable.ts
@@ -11,7 +11,8 @@ export type FetchOptions = {
   headers?: MultiMap,
   query?: MultiMap,
   body?: AnyValue,
-  security?: string,
+  /** Security configs to apply to this request. Specifying a string is equal to using `first-valid` */
+  security?: string | { kind: 'first-valid', ids: string[] } | { kind: 'all', ids: string[] },
 };
 
 // Can't use Record<string, AnyValue> but can use { [s in string]: AnyValue }. Typescript go brr.

--- a/core_js/map-std/src/unstable.ts
+++ b/core_js/map-std/src/unstable.ts
@@ -203,6 +203,11 @@ export function fetch(url: string, options: FetchOptions): HttpRequest {
     finalBody = Array.from(bodyBuffer.inner.data);
   }
 
+  let security = options.security
+  if (typeof security === "string") {
+    security = { kind: "first-valid", ids: [security] }
+  }
+
   const response = messageExchange({
     kind: 'http-call',
     method: options.method ?? 'GET',
@@ -210,7 +215,7 @@ export function fetch(url: string, options: FetchOptions): HttpRequest {
     headers,
     query: ensureMultimap(options.query ?? {}),
     body: finalBody,
-    security: options.security,
+    security,
   });
 
   if (response.kind === 'ok') {

--- a/examples/comlinks/src/localhost.provider.json
+++ b/examples/comlinks/src/localhost.provider.json
@@ -18,6 +18,12 @@
       "id": "basic_auth",
       "type": "http",
       "scheme": "basic"
+    },
+    {
+      "id": "authic_base",
+      "type": "apiKey",
+      "in": "header",
+      "name": "X-API-KEY"
     }
   ]
 }

--- a/examples/comlinks/src/wasm-sdk.example.localhost.map.js
+++ b/examples/comlinks/src/wasm-sdk.example.localhost.map.js
@@ -26,6 +26,8 @@ var Example = ({ input, parameters, services }) => {
       'x-custom-header': [parameters.PARAM]
     },
     security: 'basic_auth',
+    // security: { kind: "first-valid", ids: ['authic_base', 'basic_auth'] },
+    // security: { kind: "all", ids: ['authic_base', 'basic_auth'] },
     query: {
       'foo': ['bar', 'baz'],
       'qux': ['2']

--- a/examples/python/__main__.py
+++ b/examples/python/__main__.py
@@ -36,7 +36,7 @@ try:
         { "id": 1 },
         provider = "localhost",
         parameters = { "PARAM": "parameter_value" },
-        security = { "basic_auth": { "username": "username", "password": "password" } }
+        security = { "basic_auth": { "username": "username", "password": "password" }, "authic_base": { "apikey": "api_key_value" } }
     )
     print(f"RESULT: {r}")
 except PerformError as e:


### PR DESCRIPTION
- [x] TODO: this is based on #140 so those changes will show up too until it is merged.

## Description
Adds support for specifying multiple securities in a map.

## Motivation and Context
There's been a request to be able to specify in map that I want to use first valid security from a given list. There's also been a request before to allow applying multiple securities onto one request. This PR introduces a backwards-compatible way to do both.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
